### PR TITLE
Allows setting custom shortcut for opening search page. Closes #7

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -13,11 +13,10 @@
         "default_title": "Memory overview"
     },
     "commands": {
-        "openOverview": {
+        "_execute_browser_action": {
             "suggested_key": {
                 "default": "Ctrl+Y"
-            },
-            "description": "Open your memory overview"
+            }
         }
     },
     "applications": {

--- a/src/background.js
+++ b/src/background.js
@@ -3,7 +3,7 @@ import 'src/omnibar'
 
 
 function openOverview() {
-    browser.tabs.create({
+    browser.tabs.update({
         url: '/overview/overview.html',
     })
 }
@@ -14,7 +14,7 @@ browser.browserAction.onClicked.addListener(() => {
 })
 
 browser.commands.onCommand.addListener(command => {
-    if (command === 'openOverview') {
+    if (command === '_execute_browser_action') {
         openOverview()
     }
 })


### PR DESCRIPTION
This closes #7.

Shortcuts for extensions are usually set from "settings/extensions" and clicking on button "keyboard shortcuts". This is why I haven't added this under options. Don't know if that's even possible as this is browser's job to handle shortcuts.

This PR also opens the extension in current tab instead of creating a new one.

It also removes additional action openOverview as it's shortcut is now set to "_execute_browser_action". It basicly did the same thing and it was a duplicate. When you clicked on  "settings/extensions" and "keyboard shortcuts" it even showed both. (setting a keyboard shortcut for "Activate this extension" wasn't handled but it was for openOverview). I know merged this two actions as they were supposed to do the same thing.