### PR TITLE
Link first result in omnibar to overview page. Closes #8.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "pouchdb-find": "^0.10.4",
     "pouchdb-quick-search": "^1.2.0",
     "pouchdb-upsert": "^2.0.2",
+    "query-string": "^4.3.4",
     "react": "^15.4.1",
     "react-datepicker": "^0.43.0",
     "react-dom": "^15.4.1",

--- a/src/omnibar.js
+++ b/src/omnibar.js
@@ -1,5 +1,6 @@
 import debounce from 'lodash/fp/debounce'
 import escapeHtml from 'lodash/fp/escape'
+import tldjs from 'tldjs'
 
 import { filterVisitsByQuery } from 'src/search'
 import niceTime from 'src/util/nice-time'
@@ -67,10 +68,13 @@ async function makeSuggestion(query, suggest) {
 }
 
 const acceptInput = (text, disposition) => {
-    // TODO if text is not a suggested URL, open the overview with this query.
+    // Checks whether the text is a suggested url
+    const validUrl = tldjs.isValid(text)
+    const overviewPageWithQuery = '/overview/overview.html?searchQuery=' + text
+
     switch (disposition) {
         case 'currentTab':
-            browser.tabs.update({url: text})
+            browser.tabs.update({url: validUrl ? text : overviewPageWithQuery})
             break
         case 'newForegroundTab':
             browser.tabs.create({url: text})

--- a/src/overview/components/Overview.jsx
+++ b/src/overview/components/Overview.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
 import { connect } from 'react-redux'
+import queryString from 'query-string'
 
 import * as actions from '../actions'
 import { ourState } from '../selectors'
@@ -10,6 +11,13 @@ import styles from './Overview.css'
 
 
 class Overview extends React.Component {
+    componentWillMount() {
+        const queryVariables = queryString.parse(location.search)
+        if (queryVariables && queryVariables.searchQuery) {
+            this.props.onInputChanged(queryVariables.searchQuery)
+        }
+    }
+
     componentDidMount() {
         if (this.props.grabFocusOnMount) {
             this.refs['inputQuery'].focus()


### PR DESCRIPTION
When user selects search result this now checks whether the selected result is a suggested url or a default suggestion (which includes search query). If the selected result is a search query it then opens the overview.html and adds the search query as a url variable.

Overview component then checks if the url path contains searchQuery variable and if it does it sets to searchQuery state in overview reducer. 