### PR TITLE
Link first result in omnibar to overview page. Closes #8.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "pouchdb-find": "^0.10.4",
     "pouchdb-quick-search": "^1.2.0",
     "pouchdb-upsert": "^2.0.2",
-    "query-string": "^4.3.4",
     "react": "^15.4.1",
     "react-datepicker": "^0.43.0",
     "react-dom": "^15.4.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "classnames": "^2.2.5",
     "diff-match-patch": "^1.0.0",
     "docuri": "^4.2.1",
+    "history": "^4.6.1",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
     "page-metadata-parser": "git+https://github.com/Treora/page-metadata-parser.git#npm-testable",

--- a/src/omnibar.js
+++ b/src/omnibar.js
@@ -58,7 +58,7 @@ async function makeSuggestion(query, suggest) {
         })
     } else {
         browser.omnibox.setDefaultSuggestion({
-            description: 'Found these pages in your memory:',
+            description: 'Found these pages. Click here to show all results.',
         })
     }
     const suggestions = visitDocs.map(visitToSuggestion)

--- a/src/omnibar.js
+++ b/src/omnibar.js
@@ -70,17 +70,18 @@ async function makeSuggestion(query, suggest) {
 const acceptInput = (text, disposition) => {
     // Checks whether the text is a suggested url
     const validUrl = tldjs.isValid(text)
-    const overviewPageWithQuery = '/overview/overview.html?searchQuery=' + text
+    const overviewPageWithQuery = '/overview/overview.html?q=' + text
+    const goToUrl = validUrl ? text : overviewPageWithQuery
 
     switch (disposition) {
         case 'currentTab':
-            browser.tabs.update({url: validUrl ? text : overviewPageWithQuery})
+            browser.tabs.update({url: goToUrl})
             break
         case 'newForegroundTab':
-            browser.tabs.create({url: text})
+            browser.tabs.create({url: goToUrl})
             break
         case 'newBackgroundTab':
-            browser.tabs.create({url: text, active: false})
+            browser.tabs.create({url: goToUrl, active: false})
             break
     }
 }

--- a/src/overview/components/Overview.jsx
+++ b/src/overview/components/Overview.jsx
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react'
 import { connect } from 'react-redux'
-import queryString from 'query-string'
 
 import * as actions from '../actions'
 import { ourState } from '../selectors'
@@ -11,13 +10,6 @@ import styles from './Overview.css'
 
 
 class Overview extends React.Component {
-    componentWillMount() {
-        const queryVariables = queryString.parse(location.search)
-        if (queryVariables && queryVariables.searchQuery) {
-            this.props.onInputChanged(queryVariables.searchQuery)
-        }
-    }
-
     componentDidMount() {
         if (this.props.grabFocusOnMount) {
             this.refs['inputQuery'].focus()

--- a/src/overview/enhancer.js
+++ b/src/overview/enhancer.js
@@ -1,0 +1,24 @@
+import { compose } from 'redux'
+
+import ReduxQuerySync from 'src/util/redux-query-sync'
+import { ourState } from './selectors'
+import { setQuery } from './actions'
+
+// Keep search query in sync with the query parameter in the window location.
+const locationSync = ReduxQuerySync.enhancer({
+    replaceState: true, // We don't want back/forward to stop at every change.
+    initialTruth: 'location', // Initialise store from current location.
+    params: {
+        q: {
+            selector: state => ourState(state).query,
+            action: query => setQuery({query}),
+            defaultValue: '',
+        },
+    },
+})
+
+const enhancer = compose(
+    locationSync,
+)
+
+export default enhancer

--- a/src/overview/index.js
+++ b/src/overview/index.js
@@ -1,6 +1,7 @@
 import reducer from './reducer'
 import * as actions from './actions'
 import * as epics from './epics'
+import enhancer from './enhancer'
 import Overview from './components/Overview'
 
-export default {reducer, actions, epics, components: { Overview }}
+export default {reducer, actions, epics, enhancer, components: { Overview }}

--- a/src/overview/store.js
+++ b/src/overview/store.js
@@ -14,6 +14,7 @@ const rootEpic = combineEpics(
 
 export default function configureStore({ReduxDevTools = undefined} = {}) {
     const enhancers = [
+        overview.enhancer,
         applyMiddleware(
             createEpicMiddleware(rootEpic),
             thunk

--- a/src/util/redux-query-sync.js
+++ b/src/util/redux-query-sync.js
@@ -1,0 +1,128 @@
+import createHistory from 'history/createBrowserHistory'
+
+// Helps to keep configured query parameters of the window location in sync
+// (bidirectionally) with values in the Redux store.
+function ReduxQuerySync({
+    store,
+    params,
+    replaceState,
+    initialTruth,
+}) {
+    const { dispatch } = store
+
+    const history = createHistory()
+
+    const updateLocation = replaceState
+        ? history.replace.bind(history)
+        : history.push.bind(history)
+
+    // A bit of state used to not respond to self-induced location updates.
+    let ignoreLocationUpdate = false
+
+    // Keeps the last seen values for comparing what has changed.
+    let lastQueryValues = {}
+
+    function getQueryValues(location) {
+        const locationParams = new URL('http://bogus' + location.search).searchParams
+        const queryValues = {}
+        Object.keys(params).forEach(param => {
+            const { defaultValue } = params[param]
+            let value = locationParams.get(param)
+            if (value === null) {
+                value = defaultValue
+            }
+            queryValues[param] = value
+        })
+        return queryValues
+    }
+
+    function handleLocationUpdate(location) {
+        // Ignore the event if the location update was induced by ourselves.
+        if (ignoreLocationUpdate) return
+
+        const state = store.getState()
+
+        // Read the values of the watched parameters
+        const queryValues = getQueryValues(location)
+
+        // For each parameter value that changed, call the corresponding action.
+        Object.keys(queryValues).forEach(param => {
+            const value = queryValues[param]
+            if (value !== lastQueryValues[param]) {
+                const { selector, action } = params[param]
+                lastQueryValues[param] = value
+
+                // Dispatch the action to update the state if needed.
+                // (except on initialisation, this should always be needed)
+                if (selector(state) !== value) {
+                    dispatch(action(value))
+                }
+            }
+        })
+    }
+
+    function handleStateUpdate() {
+        const state = store.getState()
+        const location = history.location
+
+        // Parse the current location's query string.
+        const locationParams = new URL('http://bogus' + location.search).searchParams
+
+        // Replace each configured parameter with its value in the state.
+        Object.keys(params).forEach(param => {
+            const { selector, defaultValue } = params[param]
+            const value = selector(state)
+            if (value === defaultValue) {
+                locationParams.delete(param)
+            } else {
+                locationParams.set(param, value)
+            }
+        })
+        const newLocationSearchString = `?${locationParams}`
+
+        // Only update location if anything changed.
+        if (newLocationSearchString !== location.search) {
+            // Update location (but prevent triggering a state update).
+            ignoreLocationUpdate = true
+            updateLocation({search: newLocationSearchString})
+            ignoreLocationUpdate = false
+        }
+    }
+
+    // Sync location to store on every location change, and vice versa.
+    const unsubscribeFromLocation = history.listen(handleLocationUpdate)
+    const unsubscribeFromStore = store.subscribe(handleStateUpdate)
+
+    // Sync location to store now, or vice versa, or neither.
+    if (initialTruth === 'location') {
+        handleLocationUpdate(history.location)
+    } else {
+        // Just set the last seen values to later compare what changed.
+        lastQueryValues = getQueryValues(history.location)
+    }
+    if (initialTruth === 'store') {
+        handleStateUpdate()
+    }
+
+    return function unsubscribe() {
+        unsubscribeFromLocation()
+        unsubscribeFromStore()
+    }
+}
+
+// Also offer the function as a store enhancer for convenience.
+function makeStoreEnhancer(config) {
+    return storeCreator => (reducer, initialState, enhancer) => {
+        // Create the store as usual.
+        const store = storeCreator(reducer, initialState, enhancer)
+
+        // Hook up our listeners.
+        ReduxQuerySync({store, ...config})
+
+        return store
+    }
+}
+
+ReduxQuerySync.enhancer = makeStoreEnhancer
+
+export default ReduxQuerySync


### PR DESCRIPTION
Sorry, also had to create this new PR for the same reason (deleted fork).

When user selects search result this now checks whether the selected result is a suggested url or a default suggestion (which includes search query). If the selected result is a search query it then opens the overview.html and adds the search query as a url variable (named "q").

I've cherry picked Treora's commit that implement redux-query-sync. His code now replaces my old check for url variables inside of Overview component and it's now removed in last commit.