### PR TITLE
Only show latest visit. Closes #28

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "redux-act": "^1.1.0",
     "redux-observable": "^0.12.2",
     "redux-thunk": "^2.1.0",
+    "reselect": "^3.0.1",
     "rxjs": "^5.0.3",
     "tldjs": "^1.7.0",
     "webextension-polyfill": "^0.1.0"

--- a/src/overview/components/Overview.jsx
+++ b/src/overview/components/Overview.jsx
@@ -40,6 +40,7 @@ class Overview extends React.Component {
                         searchQuery={this.props.query}
                         onBottomReached={this.props.onBottomReached}
                         waitingForResults={this.props.waitingForResults}
+                        {...this.props.searchMetaData}
                     />
                 </div>
             </div>
@@ -57,6 +58,10 @@ Overview.propTypes = {
     onEndDateChange: PropTypes.func,
     onBottomReached: PropTypes.func,
     waitingForResults: PropTypes.bool,
+    searchMetaData: PropTypes.shape({
+        searchedUntil: PropTypes.string.isRequired,
+        resultsExhausted: PropTypes.bool.isRequired,
+    }).isRequired,
     searchResult: PropTypes.arrayOf(PropTypes.shape({
         latestResult: PropTypes.object.isRequired,
         rest: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -68,6 +73,7 @@ const mapStateToProps = state => ({
     ...selectors.ourState(state),
     waitingForResults: !!selectors.ourState(state).waitingForResults, // cast to boolean
     searchResult: selectors.results(state),
+    searchMetaData: selectors.searchMetaData(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/overview/components/Overview.jsx
+++ b/src/overview/components/Overview.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
 import * as actions from '../actions'
-import { ourState } from '../selectors'
+import * as selectors from '../selectors'
 import ResultList from './ResultList'
 import DateRangeSelection from './DateRangeSelection'
 import styles from './Overview.css'
@@ -57,13 +57,17 @@ Overview.propTypes = {
     onEndDateChange: PropTypes.func,
     onBottomReached: PropTypes.func,
     waitingForResults: PropTypes.bool,
-    searchResult: PropTypes.object,
+    searchResult: PropTypes.arrayOf(PropTypes.shape({
+        latestResult: PropTypes.object.isRequired,
+        rest: PropTypes.arrayOf(PropTypes.object).isRequired,
+    })).isRequired,
 }
 
 
 const mapStateToProps = state => ({
-    ...ourState(state),
-    waitingForResults: !!ourState(state).waitingForResults, // cast to boolean
+    ...selectors.ourState(state),
+    waitingForResults: !!selectors.ourState(state).waitingForResults, // cast to boolean
+    searchResult: selectors.results(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/overview/components/ResultList.jsx
+++ b/src/overview/components/ResultList.jsx
@@ -59,6 +59,7 @@ const ResultList = ({
     searchQuery,
     waitingForResults,
     onBottomReached,
+    resultsExhausted,
 }) => {
     // If there are no results, show a message.
     const noResultMessage = 'no results'
@@ -95,7 +96,7 @@ const ResultList = ({
     })
 
     // Insert waypoint to trigger loading new items when scrolling down.
-    if (!waitingForResults && !searchResult.resultsExhausted) {
+    if (!waitingForResults && !resultsExhausted) {
         const waypoint = <Waypoint onEnter={onBottomReached} key='waypoint' />
         // Put the waypoint a bit before the bottom, except if the list is short.
         const waypointPosition = Math.max(Math.min(5, listItems.length), listItems.length - 5)
@@ -117,6 +118,7 @@ ResultList.propTypes = {
     })).isRequired,
     searchQuery: PropTypes.string,
     waitingForResults: PropTypes.bool,
+    resultsExhausted: PropTypes.bool.isRequired,
     onBottomReached: PropTypes.func,
 }
 

--- a/src/overview/components/ResultList.jsx
+++ b/src/overview/components/ResultList.jsx
@@ -24,10 +24,10 @@ const timeGapToSpaceGap = makeNonlinearTransform({
 
 function computeRowGaps({searchResult}) {
     // The space and possibly a time stamp before each row
-    return searchResult.rows.map((row, rowIndex) => {
+    return searchResult.map(({ latestResult: row }, rowIndex) => {
         // Space between two rows depends on the time between them.
-        const prevRow = searchResult.rows[rowIndex - 1]
-        const prevTimestamp = prevRow ? prevRow.doc.visitStart : new Date()
+        const prevRow = searchResult[rowIndex - 1]
+        const prevTimestamp = prevRow ? prevRow.latestResult.doc.visitStart : new Date()
         const timestamp = row.doc.visitStart
         let spaceGap = 0
         if (timestamp) {
@@ -62,7 +62,7 @@ const ResultList = ({
 }) => {
     // If there are no results, show a message.
     const noResultMessage = 'no results'
-    if (searchResult.rows.length === 0
+    if (searchResult.length === 0
         && searchQuery !== ''
         && !waitingForResults
     ) {
@@ -75,7 +75,7 @@ const ResultList = ({
 
     const rowGaps = computeRowGaps({searchResult})
 
-    const listItems = searchResult.rows.map((row, rowIndex) => {
+    const listItems = searchResult.map(({ latestResult: row }, rowIndex) => {
         const { marginTop, timestampComponent } = rowGaps[rowIndex]
 
         return (
@@ -111,7 +111,10 @@ const ResultList = ({
 }
 
 ResultList.propTypes = {
-    searchResult: PropTypes.object,
+    searchResult: PropTypes.arrayOf(PropTypes.shape({
+        latestResult: PropTypes.object.isRequired,
+        rest: PropTypes.arrayOf(PropTypes.object).isRequired,
+    })).isRequired,
     searchQuery: PropTypes.string,
     waitingForResults: PropTypes.bool,
     onBottomReached: PropTypes.func,

--- a/src/overview/selectors.js
+++ b/src/overview/selectors.js
@@ -21,3 +21,8 @@ export const results = createSelector(searchResult, ({ rows: results } = {}) =>
         safelyGet('doc.url')
     )(results)
     .map(resultsStateShape)) // Final map over the groupBy output to make nicer UI state
+
+export const searchMetaData = createSelector(searchResult, searchResult => ({
+    searchedUntil: searchResult.searchedUntil,
+    resultsExhausted: searchResult.resultsExhausted,
+}))

--- a/src/overview/selectors.js
+++ b/src/overview/selectors.js
@@ -1,5 +1,23 @@
+import { createSelector } from 'reselect'
 
-// Gets this module's namespace within the full redux state
-export function ourState(rootState) {
-    return rootState.overview
-}
+import safelyGet from 'src/util/safe-nested-access'
+import orderedGroupBy from 'src/util/ordered-group-by'
+
+export const ourState = state => state.overview
+const searchResult = state => ourState(state).searchResult
+
+/**
+ * `latestResult` will contain the latest visit (to display in ResultsList);
+ * `rest` contains the later visits as an array in original order of appearance (relevance + time)
+ */
+const resultsStateShape = ([latestResult, ...rest]) => ({ latestResult, rest })
+
+/**
+ * Given the search results, group them by URL and shape them so that the UI can easily pick out the
+ * latest visit for display in the main view, and the later visits to display on-demand.
+ */
+export const results = createSelector(searchResult, ({ rows: results } = {}) =>
+    orderedGroupBy(
+        safelyGet('doc.url')
+    )(results)
+    .map(resultsStateShape)) // Final map over the groupBy output to make nicer UI state

--- a/src/util/ordered-group-by.js
+++ b/src/util/ordered-group-by.js
@@ -1,0 +1,37 @@
+import identity from 'lodash/identity'
+
+/**
+ * Does a group by on a collection, while maintaining the collection's sort order by outputting
+ * a nested array. Interface tries to mirror lodash's fp groupBy function, however iteratee assumes
+ * function type to simplify code (lodash also accepts strings via _.property fn).
+ *
+ * @param {(any) => any} iteratee Fn to grab the value from the items in coll to "group" on. Default is _.identity fn.
+ * @param {Array<any>} coll Array of any values to group by value denoted by in iteratee fn.
+ * @return {Array<Array<any>>} Array of arrays denoting the groups found. Array order will be based on the input array.
+ *  Sub-array orders, containing the grouped items, will be ordered based on the order of those items from the original
+ *  input array (index 0 is earliest in input array, index `length - 1` is latest).
+ */
+const orderedGroupBy = (iteratee = identity) => (coll = []) => {
+    // Stores ordered grouping data temporarily; unique groups afforded by object key constraints
+    const tmp = {}
+    // Grouped version of the input collection; will ref values of the tmp object
+    const groupedColl = []
+
+    coll.forEach(item => {
+        const groupKey = iteratee(item)
+        if (!groupKey) { return } // If the groupby key is missing, skip it (left out of the result)
+
+        // Create new group if not already there
+        if (!tmp[groupKey]) {
+            tmp[groupKey] = []
+            groupedColl.push(tmp[groupKey]) // Ref the array holding the grouped data
+        }
+
+        // Add new item to the tmp grouped data array
+        tmp[groupKey].push(item)
+    })
+
+    return groupedColl
+}
+
+export default orderedGroupBy

--- a/src/util/safe-nested-access.js
+++ b/src/util/safe-nested-access.js
@@ -1,0 +1,22 @@
+/**
+ * @param {string} path Path of nested object keys delimited by period ('.').
+ * @return {Array<string>} Array of object keys in order of nesting.
+ */
+const strPathToArr = path => path.split('.')
+
+/**
+ * Allows safe access to deeply nested values in an object without needing conditionals or worring about
+ * TypeErrors from attemping access on undefined keys.
+ * Idea stolen from:
+ * https://medium.com/javascript-inside/safely-accessing-deeply-nested-values-in-javascript-99bf72a0855a
+ *
+ * @param {string} path Standard object string path, denoting path of nested keys in an object delimted by period ('.')
+ *  eg: with input: { a: { b: { c: 3 } } }, you could pass 'a.b.c' to safely grab 3 without worrying about TypeErrors
+ *  being thrown in the case that a or b is undefined.
+ * @param {any} object The object to attempt to get the value expressed via pathArr.
+ * @return {any|null} Either the value found at pathArr on object, or null if it cannot be found.
+ */
+const safelyGet = (path = '') => (object = {}) =>
+    strPathToArr(path).reduce((xs, x) => (xs && xs[x]) ? xs[x] : null, object)
+
+export default safelyGet


### PR DESCRIPTION
Main idea (discussed in issue #28) is to group results state by URL (later group by page doc, depending on the outcome of #17) and only display the latest results in those groups. Essentially just selector/state derivation logic + container state->view mapping logic. 

### Progress

So far have implemented the main state derivation logic:

- custom groupBy-type fn, inspired by lodash's `groupBy`, which also preserves the ordering of the input collection by outputting an array of arrays (array of ordered groups)
- safe access to deep nested object values helper fn (used as the `iteratee` input to the ordered `groupBy`)
- selector derivation logic using those generically-written fns + state shape mapping to form the search results state

### TODO

Now need to write container logic to map the search results state to results list view. Currently the mapping of results state to view isn't separated from the view logic itself. Initial instinct is to decouple this and refactor this code back to a container and write separate dumb views, but may choose to keep in view for now to minimise the amount of changes with upstream.

### State shape

Derived search results state shape affords simple access to the latest visit/result (`latestResult`) and an array of later visits/results with the same URL, ordered by original `db.search` call's results (`rest`):
```typescript
// IVisitDoc type is the general structure of visit docs in our DB
interface IResultState {
    latestResult: IVisitDoc; // Will be mapped to the current view
    rest: Array<IVisitDoc>; // Won't be touched by container, but future plans to have a dropdown view
}

// Maintains order of original `db.search` call
const searchResultsState: Array<IResultState>
```