### PR TITLE
Limit freeze dry versions. Closes #42

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -30,6 +30,7 @@
     },
     "permissions": [
         "<all_urls>",
+        "idle",
         "bookmarks",
         "history",
         "tabs",

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -66,12 +66,18 @@ hr {
 }
 
 .popup-item-button {
-  border: none;
-  background: none;
-  width: 100%;
-  padding: 0;
-  font-size: 1em;
-  cursor: pointer;
+    border: none;
+    background: none;
+    width: 100%;
+    padding: 0;
+    font-size: 1em;
+    cursor: pointer;
+}
+
+.popup-item-button:disabled {
+    color: #9c9c9c;
+    cursor: unset;
+    background: none;
 }
 
 .popup-item-button:focus {

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -64,3 +64,16 @@ hr {
     color:#3EB995;
     background: rgb(229, 229, 229);
 }
+
+.popup-item-button {
+  border: none;
+  background: none;
+  width: 100%;
+  padding: 0;
+  font-size: 1em;
+  cursor: pointer;
+}
+
+.popup-item-button:focus {
+    outline: 0;
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -27,6 +27,11 @@
                 <i class="material-icons">file_download</i>
                 Import History &amp; Bookmarks
             </a>
+
+            <button id="archive-button" class="popup-item popup-item-button">
+                <i class="material-icons">archive</i>
+                Archive Current Page
+            </button>
         </div>
 
         <script src="/lib/browser-polyfill.js"></script>

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -57,7 +57,7 @@ const sourceFiles = [
         destination: './extension/page-viewer',
     },
     {
-        entries: ['./src/popup.js'],
+        entries: ['./src/popup/index.js'],
         output: 'popup.js',
         destination: './extension',
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "chrono-node": "^1.3.1",
     "classnames": "^2.2.5",
     "core-js": "^2.4.1",
+    "cron": "^1.2.1",
     "diff-match-patch": "^1.0.0",
     "docuri": "^4.2.2",
     "history": "^4.6.3",

--- a/src/background.js
+++ b/src/background.js
@@ -1,11 +1,20 @@
 import tldjs from 'tldjs'
+import { CronJob } from 'cron'
 
 import 'src/activity-logger/background'
 import 'src/omnibar'
 import { installTimeStorageKey } from 'src/imports/background'
 import convertOldData from 'src/util/old-data-converter'
+import cleanupFreezeDry from 'src/page-storage/cleanup'
 
 export const dataConvertTimeKey = 'data-conversion-timestamp'
+
+// Schedule freeze-dry cleanups every 30 mins
+export const freezeDryJob = new CronJob({
+    cronTime: '0 */30 * * * *',
+    onTick: cleanupFreezeDry,
+    start: true,
+})
 
 async function openOverview() {
     const [ currentTab ] = await browser.tabs.query({ active: true })

--- a/src/background.js
+++ b/src/background.js
@@ -11,8 +11,8 @@ export const dataConvertTimeKey = 'data-conversion-timestamp'
 
 // Schedule freeze-dry cleanups every 30 mins
 export const freezeDryJob = new CronJob({
-    cronTime: '0 */30 * * * *',
-    onTick: cleanupFreezeDry,
+    cronTime: '* */30 * * * *',
+    onTick: cleanupFreezeDry(),
     start: true,
 })
 

--- a/src/background.js
+++ b/src/background.js
@@ -1,20 +1,13 @@
 import tldjs from 'tldjs'
-import { CronJob } from 'cron'
 
 import 'src/activity-logger/background'
+import 'src/scheduled-tasks/background'
 import 'src/omnibar'
 import { installTimeStorageKey } from 'src/imports/background'
 import convertOldData from 'src/util/old-data-converter'
-import cleanupFreezeDry from 'src/page-storage/cleanup'
 
 export const dataConvertTimeKey = 'data-conversion-timestamp'
 
-// Schedule freeze-dry cleanups every 30 mins
-export const freezeDryJob = new CronJob({
-    cronTime: '* */30 * * * *',
-    onTick: cleanupFreezeDry(),
-    start: true,
-})
 
 async function openOverview() {
     const [ currentTab ] = await browser.tabs.query({ active: true })

--- a/src/options/containers/settings/index.jsx
+++ b/src/options/containers/settings/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import Blacklist from '../../blacklist'
+import Preferences from '../../preferences'
 import { routeTitle, sectionTitle } from '../../base.css'
 import styles from './style.css'
 
@@ -12,6 +13,11 @@ const SettingsContainer = () => (
             <h2 className={sectionTitle}>Ignored Sites</h2>
 
             <Blacklist />
+        </section>
+        <section className={styles.section}>
+            <h2 className={sectionTitle}>Miscellaneous Preferences</h2>
+
+            <Preferences />
         </section>
     </div>
 )

--- a/src/options/preferences/actions.js
+++ b/src/options/preferences/actions.js
@@ -1,0 +1,4 @@
+import { createAction } from 'redux-act'
+
+export const setFreezeDryBookmarks = createAction('prefs/setFreezeDryBookmarks')
+export const toggleFreezeDryBookmarks = createAction('prefs/toggleFreezeDryBookmarks')

--- a/src/options/preferences/components/Preferences.css
+++ b/src/options/preferences/components/Preferences.css
@@ -1,0 +1,9 @@
+.flagsList {
+    list-style: none;
+    padding-left: 5px;
+}
+
+.flagsListItem {
+    font-size: 0.9em;
+    height: 30px;
+}

--- a/src/options/preferences/components/Preferences.jsx
+++ b/src/options/preferences/components/Preferences.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import styles from './Preferences.css'
+
+const Preferences = ({ toggleFreezeDryBookmarks, freezeDryBookmarks }) => (
+    <div>
+        <ul className={styles.flagsList}>
+            <li className={styles.flagsListItem}>
+                <input
+                    type='checkbox'
+                    id='freezeDryBookmarksCheckbox'
+                    onChange={toggleFreezeDryBookmarks}
+                    checked={freezeDryBookmarks}
+                />
+                <label htmlFor='freezeDryBookmarksCheckbox'>Store bookmarks for offline viewing</label>
+            </li>
+        </ul>
+    </div>
+)
+
+Preferences.propTypes = {
+    freezeDryBookmarks: PropTypes.bool.isRequired,
+    toggleFreezeDryBookmarks: PropTypes.func.isRequired,
+}
+
+export default Preferences

--- a/src/options/preferences/constants.js
+++ b/src/options/preferences/constants.js
@@ -1,0 +1,1 @@
+export const FREEZE_DRY_BOOKMARKS_KEY = 'freeze-dry-bookmarks'

--- a/src/options/preferences/container.js
+++ b/src/options/preferences/container.js
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux'
+
+import Preferences from './components/Preferences'
+import * as selectors from './selectors'
+import * as actions from './actions'
+
+const mapStateToProps = state => ({
+    freezeDryBookmarks: selectors.freezeDryBookmarks(state),
+})
+
+const mapDispatchToProps = dispatch => ({
+    toggleFreezeDryBookmarks: () => dispatch(actions.toggleFreezeDryBookmarks()),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(Preferences)

--- a/src/options/preferences/enhancer.js
+++ b/src/options/preferences/enhancer.js
@@ -1,0 +1,24 @@
+import * as actions from './actions'
+import * as selectors from './selectors'
+import { FREEZE_DRY_BOOKMARKS_KEY } from './constants'
+
+const hydratePrefsFromStorage = store =>
+    browser.storage.local.get(FREEZE_DRY_BOOKMARKS_KEY).then(storage =>
+        store.dispatch(actions.setFreezeDryBookmarks(storage[FREEZE_DRY_BOOKMARKS_KEY] || false)))
+
+const syncPrefsToStorage = store => store.subscribe(() => {
+    const isFreezeDryBmEnabled = selectors.freezeDryBookmarks(store.getState())
+    browser.storage.local.set({ [FREEZE_DRY_BOOKMARKS_KEY]: isFreezeDryBmEnabled })
+})
+
+export default storeCreator => (reducer, initState, enhancer) => {
+    const store = storeCreator(reducer, initState, enhancer)
+
+    // Subscribe to changes and update local storage
+    syncPrefsToStorage(store)
+
+    // Rehydrate blacklist on init from local storage
+    hydratePrefsFromStorage(store)
+
+    return store
+}

--- a/src/options/preferences/index.js
+++ b/src/options/preferences/index.js
@@ -1,0 +1,6 @@
+import * as actions from './actions'
+import * as constants from './constants'
+export { default as reducer } from './reducers'
+export { default as enhancer } from './enhancer'
+export { default } from './container'
+export { actions, constants }

--- a/src/options/preferences/reducers.js
+++ b/src/options/preferences/reducers.js
@@ -1,0 +1,11 @@
+import { createReducer } from 'redux-act'
+import * as actions from './actions'
+
+const defaultState = {
+    freezeDryBookmarks: false,
+}
+
+export default createReducer({
+    [actions.toggleFreezeDryBookmarks]: state => ({ ...state, freezeDryBookmarks: !state.freezeDryBookmarks }),
+    [actions.setFreezeDryBookmarks]: (state, freezeDryBookmarks) => ({ ...state, freezeDryBookmarks }),
+}, defaultState)

--- a/src/options/preferences/selectors.js
+++ b/src/options/preferences/selectors.js
@@ -1,0 +1,5 @@
+import { createSelector } from 'reselect'
+
+export const entireState = state => state.preferences
+
+export const freezeDryBookmarks = createSelector(entireState, state => state.freezeDryBookmarks)

--- a/src/options/store.js
+++ b/src/options/store.js
@@ -1,18 +1,21 @@
 import { createStore, combineReducers, compose, applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
 
-import * as blacklist from './blacklist'
 import * as imports from './imports'
+import * as preferences from './preferences'
+import * as blacklist from './blacklist'
 
 const rootReducer = combineReducers({
     blacklist: blacklist.reducer,
     imports: imports.reducer,
+    preferences: preferences.reducer,
 })
 
 export default function configureStore({ReduxDevTools = undefined} = {}) {
     const enhancers = [
         blacklist.enhancer,
         imports.enhancer,
+        preferences.enhancer,
         applyMiddleware(
             thunk,
         ),

--- a/src/page-storage/cleanup.js
+++ b/src/page-storage/cleanup.js
@@ -1,0 +1,41 @@
+import db from 'src/pouchdb'
+import { FREEZE_DRY_BOOKMARKS_KEY } from 'src/options/preferences/constants'
+import { pageDocsSelector } from './'
+
+const freezeDryAttachmentId = 'frozen-page.html'
+
+const getQuery = ({ skipBookmarkPages = false, skip = 100, customFields = [] }) => {
+    // TODO: Replace this with actual bookmarks flag on page docs from bookmark creation event
+    const bookmarksFlagSelector = skipBookmarkPages ? { isBookmarkPage: { $ne: true } } : {}
+
+    return {
+        selector: {
+            ...pageDocsSelector,
+            keepFreezeDry: { $ne: true },
+            ...bookmarksFlagSelector,
+        },
+        skip,
+        sort: [{ _id: 'desc' }],
+        fields: ['_id', '_rev', ...customFields],
+    }
+}
+
+/**
+ * Handle removal of freeze-dry attachments from page docs that match the following criteria:
+ *  - not in the 100 latest page docs
+ *  - not manually specified by user to keep (`keepFreezeDry` flag)
+ *  - not associated with created bookmark doc (if user-option set)
+ */
+export default async function cleanupFreezeDry() {
+    const skipBookmarkPages = (await browser.storage.local.get(FREEZE_DRY_BOOKMARKS_KEY))[FREEZE_DRY_BOOKMARKS_KEY]
+
+    const { docs } = await db.find(getQuery({ skipBookmarkPages, customFields: ['_attachments'] }))
+
+    // Remove freeze dry attachment from docs if present
+    for (const doc of docs) {
+        // TODO: replace this check with $exists in query
+        if (doc._attachments && doc._attachments[freezeDryAttachmentId]) {
+            await db.removeAttachment(doc._id, freezeDryAttachmentId, doc._rev)
+        }
+    }
+}

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,9 +1,41 @@
 import qs from 'query-string'
+import last from 'lodash/fp/last'
 
+import db from 'src/pouchdb'
 import extractTimeFiltersFromQuery from 'src/util/nlp-time-filter.js'
+import { pageDocsSelector } from 'src/page-storage'
+import updateDoc from 'src/util/pouchdb-update-doc'
 
 const overviewURL = 'overview/overview.html'
 const input = document.getElementById('search')
+const archiveBtn = document.getElementById('archive-button')
+
+/**
+ * Attempts to get the ID of the page doc matching the current tab.
+ * @return {string} The ID of the matching page doc
+ * @throws Will throw an error if URL cannot be gotten from tab or matching page docs not found.
+ */
+const getCurrentTabPageDocId = async () => {
+    const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })
+
+    if (!currentTab || !currentTab.url) {
+        throw new Error('Cannot get current tab to archive pages for')
+    }
+
+    const selector = { ...pageDocsSelector, url: currentTab.url }
+    const { docs } = await db.find({ selector, fields: ['_id'] })
+
+    if (!docs || !docs.length) {
+        throw new Error('Cannot find page doc matching current tab for archiving')
+    }
+
+    return last(docs)._id // Latest should be at the end
+}
+
+const setFreezeDryFlag = doc => {
+    doc.keepFreezeDry = true
+    return doc
+}
 
 input.addEventListener('keydown', event => {
     if (event.keyCode === 13) { // If 'Enter' pressed
@@ -14,5 +46,20 @@ input.addEventListener('keydown', event => {
 
         browser.tabs.create({ url: `${overviewURL}?${queryParams}` }) // New tab with query
         window.close() // Close the popup
+    }
+})
+
+// Runs to set flag on matching page doc. Flag says to save associated freeze-dry (others cleaned up over time)
+archiveBtn.addEventListener('click', async event => {
+    event.preventDefault()
+
+    try {
+        const pageId = await getCurrentTabPageDocId()
+        await updateDoc(db, pageId, setFreezeDryFlag)
+    } catch (error) {
+        // Something bad happened; cannot be archived
+        console.error(error)
+    } finally {
+        window.close()
     }
 })

--- a/src/popup/archive-button.js
+++ b/src/popup/archive-button.js
@@ -1,14 +1,9 @@
-import qs from 'query-string'
-import last from 'lodash/fp/last'
-
 import db from 'src/pouchdb'
-import extractTimeFiltersFromQuery from 'src/util/nlp-time-filter.js'
+import last from 'lodash/fp/last'
 import { pageDocsSelector } from 'src/page-storage'
 import updateDoc from 'src/util/pouchdb-update-doc'
 
-const overviewURL = 'overview/overview.html'
-const input = document.getElementById('search')
-const archiveBtn = document.getElementById('archive-button')
+export const archiveBtn = document.getElementById('archive-button')
 
 /**
  * Attempts to get the ID of the page doc matching the current tab.
@@ -70,18 +65,5 @@ archiveBtn.addEventListener('click', async event => {
         console.error(error)
     } finally {
         window.close()
-    }
-})
-
-// Converts an enter press on the input to convert the NLP queries and forward user to overview search
-input.addEventListener('keydown', event => {
-    if (event.keyCode === 13) { // If 'Enter' pressed
-        event.preventDefault() // So the form doesn't submit
-
-        const { extractedQuery: query, startDate, endDate } = extractTimeFiltersFromQuery(input.value)
-        const queryParams = qs.stringify({ query, startDate, endDate })
-
-        browser.tabs.create({ url: `${overviewURL}?${queryParams}` }) // New tab with query
-        window.close() // Close the popup
     }
 })

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -1,0 +1,2 @@
+import './search-input'
+import './archive-button'

--- a/src/popup/search-input.js
+++ b/src/popup/search-input.js
@@ -1,0 +1,19 @@
+import qs from 'query-string'
+
+import extractTimeFiltersFromQuery from 'src/util/nlp-time-filter.js'
+
+const overviewURL = 'overview/overview.html'
+export const input = document.getElementById('search')
+
+// Converts an enter press on the input to convert the NLP queries and forward user to overview search
+input.addEventListener('keydown', event => {
+    if (event.keyCode === 13) { // If 'Enter' pressed
+        event.preventDefault() // So the form doesn't submit
+
+        const { extractedQuery: query, startDate, endDate } = extractTimeFiltersFromQuery(input.value)
+        const queryParams = qs.stringify({ query, startDate, endDate })
+
+        browser.tabs.create({ url: `${overviewURL}?${queryParams}` }) // New tab with query
+        window.close() // Close the popup
+    }
+})

--- a/src/scheduled-tasks/background/freeze-dry-cleanup.js
+++ b/src/scheduled-tasks/background/freeze-dry-cleanup.js
@@ -1,6 +1,6 @@
 import db from 'src/pouchdb'
 import { FREEZE_DRY_BOOKMARKS_KEY } from 'src/options/preferences/constants'
-import { pageDocsSelector } from './'
+import { pageDocsSelector } from 'src/page-storage'
 
 const freezeDryAttachmentId = 'frozen-page.html'
 

--- a/src/scheduled-tasks/background/index.js
+++ b/src/scheduled-tasks/background/index.js
@@ -1,0 +1,10 @@
+import { CronJob } from 'cron'
+import cleanupFreezeDry from './freeze-dry-cleanup'
+import { makeDelayedTask } from '../'
+
+// Schedule freeze-dry cleanups every 30 mins, after being idle for 30 secs
+export const freezeDryCleanupTask = new CronJob({
+    cronTime: '* */30 * * * *',
+    onTick: makeDelayedTask(cleanupFreezeDry(), 30),
+    start: true,
+})

--- a/src/scheduled-tasks/background/index.js
+++ b/src/scheduled-tasks/background/index.js
@@ -1,6 +1,19 @@
+import map from 'lodash/fp/map'
+
+import db from 'src/pouchdb'
 import { CronJob } from 'cron'
 import cleanupFreezeDry from './freeze-dry-cleanup'
 import { makeDelayedTask } from '../'
+
+export const INDEXES = {
+    FREEZE_DRY: {
+        name: 'freeze-dry-cleanup-index',
+        fields: ['_id', 'keepFreezeDry', 'isStub', 'isBookmarkPage'],
+    },
+}
+
+// Ensure find indexes exist for any needed scheduled task queries
+map(index => db.createIndex({ index }))(INDEXES)
 
 // Schedule freeze-dry cleanups every 30 mins, after being idle for 30 secs
 export const freezeDryCleanupTask = new CronJob({

--- a/src/scheduled-tasks/index.js
+++ b/src/scheduled-tasks/index.js
@@ -2,19 +2,26 @@
  * Higher order function to make another function only be invoked when user is deemed idle.
  * Wraps around the web extension browser.idle API.
  *
- * @param {function} task Async or sync function to run after idle.
+ * @param {(any) => Promise<any>} task Async or sync function to run after idle.
  * @param {number} [idleTimeout=15] Number of seconds to consider user idle (min is 15)
+ * @return {(any) => Promise<any>} Augmented version of `task` that, when invoked, will only run when user idle.
+ *  A Promise will be returned which the invoker can use to wait for eventual output.
  */
-export const makeDelayedTask = (task, idleTimeout = 15) => () => {
+export const makeDelayedTask = (task, idleTimeout = 15) => (...args) => new Promise((resolve, reject) => {
     browser.idle.setDetectionInterval(idleTimeout)
 
     async function runWhenIdle(idleState) {
         if (idleState === 'idle') {
-            await task()
-            // Make sure to remove listner (itself) after runnings once
-            browser.idle.onStateChanged.removeListener(runWhenIdle)
+            try {
+                const output = await task(...args)
+                resolve(output)
+            } catch (error) {
+                reject(error)
+            } finally { // Make sure to remove listner (itself) after running once
+                browser.idle.onStateChanged.removeListener(runWhenIdle)
+            }
         }
     }
 
     browser.idle.onStateChanged.addListener(runWhenIdle)
-}
+})

--- a/src/scheduled-tasks/index.js
+++ b/src/scheduled-tasks/index.js
@@ -1,0 +1,20 @@
+/**
+ * Higher order function to make another function only be invoked when user is deemed idle.
+ * Wraps around the web extension browser.idle API.
+ *
+ * @param {function} task Async or sync function to run after idle.
+ * @param {number} [idleTimeout=15] Number of seconds to consider user idle (min is 15)
+ */
+export const makeDelayedTask = (task, idleTimeout = 15) => () => {
+    browser.idle.setDetectionInterval(idleTimeout)
+
+    async function runWhenIdle(idleState) {
+        if (idleState === 'idle') {
+            await task()
+            // Make sure to remove listner (itself) after runnings once
+            browser.idle.onStateChanged.removeListener(runWhenIdle)
+        }
+    }
+
+    browser.idle.onStateChanged.addListener(runWhenIdle)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1877,6 +1877,12 @@ create-react-class@^15.5.1, create-react-class@^15.5.3, create-react-class@^15.5
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+cron@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cron/-/cron-1.2.1.tgz#3a86c09b41b8f261ac863a7cc85ea4735857eab2"
+  dependencies:
+    moment-timezone "^0.5.x"
+
 cross-spawn-async@^2.1.1:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
@@ -5232,7 +5238,13 @@ module-deps@^4.0.8:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-moment@2.x.x, moment@^2.10.3, moment@^2.10.6, moment@^2.17.1, moment@^2.18.1:
+moment-timezone@^0.5.x:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.13.tgz#99ce5c7d827262eb0f1f702044177f60745d7b90"
+  dependencies:
+    moment ">= 2.9.0"
+
+moment@2.x.x, "moment@>= 2.9.0", moment@^2.10.3, moment@^2.10.6, moment@^2.17.1, moment@^2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 


### PR DESCRIPTION
Main things to do:

- [x] User can define in the settings that Freeze Dry Versions are made for each page they bookmark via the browser. For that we have to listen to the bookmark event.
- [x] They can "Archive Current Page" via a button in the Dropdown, not the same as bookmarks though
- [x] We automatically store the last 100 pages as freeze dry, and if they are not bookmarked or manually archived, we delete the freeze dry version.

Part 1 is simple. UI done for a checkbox in settings to allow user to set a flag in local storage. Implementation of this being done in #46 

Part 2 will involve a new button in popup. The button action should set a flag, say `keepFreezeDry`, on the page doc associated with the current page*. This flag will be used in part 3. Harder part is keeping the state of that button set (it's essentially a toggle); popup is in plain JS + HTML.

\* _There is no guaranteed way to get the current page. It will have to do a query on page docs with the same URL and take the latest, I guess._

Part 3 is by far the most difficult part. I'm currently thinking a scheduled task every hour (?) to remove freeze-dry attachments from all page docs that are not:
- the latest 100 page docs
- pages with `keepFreezeDry` flag set
- pages with associated bookmark doc (IF option from part 1 is set)

Will look into possibility of scheduled task in background script (__maybe [this](https://github.com/kelektiv/node-cron) if it works in browser__). Other option is to do it on the page visit event, but the queries involved will add more overhead to a page load, which we don't want.