### PR TITLE
Delete visit + assoc docs prompt. Addresses #16

### DIFF
--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -29,14 +29,12 @@ export function init() {
     }
 }
 
-export function deleteVisit(visitId) {
-    return async function (dispatch, getState) {
-        // Hide the visit + confirm modal directly (optimistically).
-        dispatch(hideVisit(visitId))
-        dispatch(hideDeleteConfirm())
-        // Remove it from the database.
-        await deleteVisitAndPage({visitId})
-    }
+export const deleteVisit = (visitId, deleteAssoc = false) => async (dispatch, getState) => {
+    // Hide the visit + confirm modal directly (optimistically).
+    dispatch(hideVisit(visitId))
+    dispatch(hideDeleteConfirm())
+    // Remove it from the database.
+    await deleteVisitAndPage({visitId, deleteAssoc})
 }
 
 export const newSearch = asyncActionCreator(() => async (dispatch, getState) => {

--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -35,6 +35,11 @@ export const deleteVisit = (visitId, deleteAssoc = false) => async (dispatch, ge
     dispatch(hideDeleteConfirm())
     // Remove it from the database.
     await deleteVisitAndPage({visitId, deleteAssoc})
+
+    // Refresh search view after deleting all assoc docs
+    if (deleteAssoc) {
+        dispatch(newSearch())
+    }
 }
 
 export const newSearch = asyncActionCreator(() => async (dispatch, getState) => {

--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -15,6 +15,8 @@ export const setQuery = createAction('overview/setQuery')
 export const setStartDate = createAction('overview/setStartDate')
 export const setEndDate = createAction('overview/setEndDate')
 export const hideVisit = createAction('overview/hideVisit')
+export const showDeleteConfirm = createAction('overview/showDeleteConfirm')
+export const hideDeleteConfirm = createAction('overview/hideDeleteConfirm')
 
 
 // == Actions that trigger other actions ==
@@ -29,8 +31,9 @@ export function init() {
 
 export function deleteVisit({visitId}) {
     return async function (dispatch, getState) {
-        // Hide the visit directly (optimistically).
+        // Hide the visit + confirm modal directly (optimistically).
         dispatch(hideVisit({visitId}))
+        dispatch(hideDeleteConfirm())
         // Remove it from the database.
         await deleteVisitAndPage({visitId})
     }

--- a/src/overview/actions.js
+++ b/src/overview/actions.js
@@ -29,10 +29,10 @@ export function init() {
     }
 }
 
-export function deleteVisit({visitId}) {
+export function deleteVisit(visitId) {
     return async function (dispatch, getState) {
         // Hide the visit + confirm modal directly (optimistically).
-        dispatch(hideVisit({visitId}))
+        dispatch(hideVisit(visitId))
         dispatch(hideDeleteConfirm())
         // Remove it from the database.
         await deleteVisitAndPage({visitId})

--- a/src/overview/components/DeleteConfirmation.css
+++ b/src/overview/components/DeleteConfirmation.css
@@ -1,6 +1,7 @@
 .buttonBar {
     display: flex;
     justify-content: space-around;
+    font-size: 0.8em;
 }
 
 .button {
@@ -67,5 +68,6 @@
     display: flex;
     flex-direction: column;
     justify-content: space-around;
+    font-size: 1.2em;
     min-height: 100px;
 }

--- a/src/overview/components/DeleteConfirmation.css
+++ b/src/overview/components/DeleteConfirmation.css
@@ -1,0 +1,71 @@
+.buttonBar {
+    display: flex;
+    justify-content: space-around;
+}
+
+.button {
+    border: none;
+    background: none;
+    transition: all 200ms;
+    cursor: pointer;
+
+    &:hover {
+        color: #3eb995;
+    }
+}
+
+.confirmButton {
+    font-size: 1.2em;
+    font-weight: 500;
+}
+
+.overlay {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(0, 0, 0, 0.7);
+    transition: opacity 500ms;
+    visibility: hidden;
+    opacity: 0;
+}
+
+.overlayShown {
+    visibility: visible;
+    opacity: 1;
+}
+
+.popup {
+    padding: 20px;
+    background: #fff;
+    border-radius: 5px;
+    width: 30%;
+    position: relative;
+    transition: all 5s ease-in-out;
+}
+
+.close {
+    position: absolute;
+    top: 5px;
+    right: 15px;
+    font-size: 2em;
+    font-weight: bold;
+    text-decoration: none;
+    color: #333;
+
+    &:hover {
+        color: #06d85f;
+    }
+}
+
+.content {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    min-height: 100px;
+}

--- a/src/overview/components/DeleteConfirmation.jsx
+++ b/src/overview/components/DeleteConfirmation.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+
+import styles from './DeleteConfirmation.css'
+
+const confirmBtnStyles = classNames(styles.confirm, styles.button, styles.confirmButton)
+const getOverlayStyles = isShown => classNames({
+    [styles.overlay]: true,
+    [styles.overlayShown]: isShown,
+})
+
+const DeleteConfirmation = ({ isShown, close, deleteAll, deleteVisit }) => (
+    <div className={getOverlayStyles(isShown)}>
+        <div className={styles.popup}>
+            <button className={classNames(styles.close, styles.button)} onClick={close}>×</button>
+            <div className={styles.content}>
+                Are you sure you want to forget this visit?
+
+                <div className={styles.buttonBar}>
+                    <button className={confirmBtnStyles} onClick={deleteVisit}>
+                        Forget visit only
+                    </button>
+                    <button className={confirmBtnStyles} onClick={deleteAll}>
+                        Forget all associated data
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+)
+
+DeleteConfirmation.propTypes = {
+    isShown: PropTypes.bool.isRequired,
+    close: PropTypes.func.isRequired,
+    deleteAll: PropTypes.func.isRequired,
+    deleteVisit: PropTypes.func.isRequired,
+}
+
+export default DeleteConfirmation

--- a/src/overview/components/DeleteConfirmation.jsx
+++ b/src/overview/components/DeleteConfirmation.jsx
@@ -15,14 +15,14 @@ const DeleteConfirmation = ({ isShown, close, deleteAll, deleteVisit }) => (
         <div className={styles.popup}>
             <button className={classNames(styles.close, styles.button)} onClick={close}>×</button>
             <div className={styles.content}>
-                Are you sure you want to forget this visit?
+                What do you want to delete?
 
                 <div className={styles.buttonBar}>
                     <button className={confirmBtnStyles} onClick={deleteVisit}>
-                        Forget visit only
+                        Only this visit
                     </button>
                     <button className={confirmBtnStyles} onClick={deleteAll}>
-                        Forget all associated data
+                        Delete all associated data
                     </button>
                 </div>
             </div>

--- a/src/overview/components/Overview.jsx
+++ b/src/overview/components/Overview.jsx
@@ -7,6 +7,7 @@ import * as actions from '../actions'
 import * as selectors from '../selectors'
 import ResultList from './ResultList'
 import DateRangeSelection from './DateRangeSelection'
+import DeleteConfirmation from './DeleteConfirmation'
 import styles from './Overview.css'
 
 
@@ -60,6 +61,12 @@ class Overview extends React.Component {
                         waitingForResults={this.props.waitingForResults}
                         {...this.props.searchMetaData}
                     />
+                    <DeleteConfirmation
+                        isShown={this.props.isDeleteConfShown}
+                        close={this.props.hideDeleteConfirm}
+                        deleteAll={this.props.deleteAssociatedDocs(this.props.deleteVisitId)}
+                        deleteVisit={this.props.deleteVisit(this.props.deleteVisitId)}
+                    />
                 </div>
             </div>
         )
@@ -86,6 +93,11 @@ Overview.propTypes = {
         latestResult: PropTypes.object.isRequired,
         rest: PropTypes.arrayOf(PropTypes.object).isRequired,
     })).isRequired,
+    isDeleteConfShown: PropTypes.bool.isRequired,
+    deleteVisitId: PropTypes.string,
+    hideDeleteConfirm: PropTypes.func.isRequired,
+    deleteAssociatedDocs: PropTypes.func.isRequired,
+    deleteVisit: PropTypes.func.isRequired,
 }
 
 
@@ -95,13 +107,20 @@ const mapStateToProps = state => ({
     waitingForResults: !!selectors.ourState(state).waitingForResults, // cast to boolean
     searchResult: selectors.results(state),
     searchMetaData: selectors.searchMetaData(state),
+    isDeleteConfShown: selectors.isDeleteConfShown(state),
+    deleteVisitId: selectors.deleteVisitId(state),
 })
 
-const mapDispatchToProps = dispatch => bindActionCreators({
-    onInputChanged: actions.setQuery,
-    onStartDateChange: actions.setStartDate,
-    onEndDateChange: actions.setEndDate,
-    onBottomReached: actions.loadMoreResults,
-}, dispatch)
+const mapDispatchToProps = dispatch => ({
+    ...bindActionCreators({
+        onInputChanged: actions.setQuery,
+        onStartDateChange: actions.setStartDate,
+        onEndDateChange: actions.setEndDate,
+        onBottomReached: actions.loadMoreResults,
+        hideDeleteConfirm: actions.hideDeleteConfirm,
+    }, dispatch),
+    deleteAssociatedDocs: visitId => () => dispatch(actions.deleteVisit(visitId)),
+    deleteVisit: visitId => () => dispatch(actions.deleteVisit(visitId)),
+})
 
 export default connect(mapStateToProps, mapDispatchToProps)(Overview)

--- a/src/overview/components/Overview.jsx
+++ b/src/overview/components/Overview.jsx
@@ -119,7 +119,7 @@ const mapDispatchToProps = dispatch => ({
         onBottomReached: actions.loadMoreResults,
         hideDeleteConfirm: actions.hideDeleteConfirm,
     }, dispatch),
-    deleteAssociatedDocs: visitId => () => dispatch(actions.deleteVisit(visitId)),
+    deleteAssociatedDocs: visitId => () => dispatch(actions.deleteVisit(visitId, true)),
     deleteVisit: visitId => () => dispatch(actions.deleteVisit(visitId)),
 })
 

--- a/src/overview/components/VisitAsListItem.jsx
+++ b/src/overview/components/VisitAsListItem.jsx
@@ -9,7 +9,7 @@ import niceTime from 'src/util/nice-time'
 
 import ImgFromPouch from './ImgFromPouch'
 import styles from './VisitAsListItem.css'
-import { deleteVisit } from '../actions'
+import { showDeleteConfirm } from '../actions'
 
 
 const VisitAsListItem = ({doc, compact, onTrashButtonClick}) => {
@@ -85,7 +85,7 @@ VisitAsListItem.propTypes = {
 const mapStateToProps = state => ({})
 
 const mapDispatchToProps = (dispatch, {doc}) => ({
-    onTrashButtonClick: () => dispatch(deleteVisit({visitId: doc._id})),
+    onTrashButtonClick: () => dispatch(showDeleteConfirm(doc._id)),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(VisitAsListItem)

--- a/src/overview/reducer.js
+++ b/src/overview/reducer.js
@@ -77,7 +77,7 @@ function finishExpandSearch(state, {value: newResult, error, cancelled}) {
     }
 }
 
-function hideVisit(state, {visitId}) {
+function hideVisit(state, visitId) {
     return update('searchResult.rows',
         rows => remove(row => row.id === visitId)(rows)
     )(state)

--- a/src/overview/reducer.js
+++ b/src/overview/reducer.js
@@ -18,6 +18,10 @@ const defaultState = {
     // The input values used in the most recent (possibly still pending) search action.
     activeQueryParams: undefined,
     waitingForResults: false,
+    deleteConfirmProps: {
+        isShown: false,
+        visitId: '',
+    },
 }
 
 function setQuery(state, query) {
@@ -79,10 +83,26 @@ function hideVisit(state, {visitId}) {
     )(state)
 }
 
+const showDeleteConfirm = (state, visitId) => ({
+    ...state,
+    deleteConfirmProps: {
+        ...state.deleteConfirmProps,
+        isShown: true,
+        visitId,
+    },
+})
+
+const hideDeleteConfirm = state => ({
+    ...state,
+    deleteConfirmProps: { ...state.deleteConfirmProps, isShown: false },
+})
+
 export default createReducer({
     [actions.setQuery]: setQuery,
     [actions.setStartDate]: setStartDate,
     [actions.setEndDate]: setEndDate,
+    [actions.showDeleteConfirm]: showDeleteConfirm,
+    [actions.hideDeleteConfirm]: hideDeleteConfirm,
     [actions.newSearch.pending]: startNewSearch,
     [actions.newSearch.finished]: finishNewSearch,
     [actions.expandSearch.pending]: startExpandSearch,

--- a/src/overview/selectors.js
+++ b/src/overview/selectors.js
@@ -25,3 +25,7 @@ export const searchMetaData = createSelector(searchResult, searchResult => ({
     searchedUntil: searchResult.searchedUntil,
     resultsExhausted: searchResult.resultsExhausted,
 }))
+
+export const deleteConfirmProps = createSelector(ourState, state => state.deleteConfirmProps)
+export const isDeleteConfShown = createSelector(deleteConfirmProps, state => state.isShown)
+export const deleteVisitId = createSelector(deleteConfirmProps, state => state.visitId)

--- a/src/page-storage/deletion.js
+++ b/src/page-storage/deletion.js
@@ -1,5 +1,6 @@
-import db from 'src/pouchdb'
+import db, { normaliseFindResult } from 'src/pouchdb'
 import { findVisits } from 'src/search/find-visits'
+import { bookmarkDocsSelector } from 'src/imports/background'
 import { getEquivalentPages } from 'src/search/find-pages'
 
 export async function deleteVisitAndPage({visitId, deleteAssoc = false}) {
@@ -9,10 +10,45 @@ export async function deleteVisitAndPage({visitId, deleteAssoc = false}) {
     await db.remove(visit)
 
     if (deleteAssoc) {
+        await deletePageAndAssociated({pageId})
+    } else {
         // If this was the only visit linking to the page, also remove the page.
         // (a simple choice for now; this behaviour may be changed in the future)
         await deletePageIfOrphaned({pageId})
     }
+}
+
+const deleteDocs = docs => db.bulkDocs(docs.map(
+    row => ({
+        _id: row.id,
+        _rev: row.value.rev,
+        _deleted: true,
+    })
+))
+
+/**
+ * Deletes a given page doc plus any visit and bookmark docs that are associated
+ * to it.
+ *
+ * @param {string} pageId The ID of the page doc to delete.
+ */
+async function deletePageAndAssociated({pageId}) {
+    const pagesResult = await getEquivalentPages({pageId})
+    const visitsResult = await findVisits({pagesResult})
+    const bookmarksResult = normaliseFindResult(await db.find({
+        selector: {
+            ...bookmarkDocsSelector,
+            'page._id': { $in: pagesResult.rows.map(row => row.id) },
+        },
+    }))
+
+    const totalDocs = [
+        ...pagesResult.rows,
+        ...visitsResult.rows,
+        ...bookmarksResult.rows,
+    ]
+
+    await deleteDocs(totalDocs)
 }
 
 async function deletePageIfOrphaned({pageId}) {
@@ -25,12 +61,6 @@ async function deletePageIfOrphaned({pageId}) {
     // (otherwise, we leave them; it does not seem worth the effort to smartly
     // prune some orphans among them already)
     if (visitsResult.rows.length === 0) {
-        await db.bulkDocs(pagesResult.rows.map(
-            row => ({
-                _id: row.id,
-                _rev: row.value.rev,
-                _deleted: true,
-            })
-        ))
+        await deleteDocs(pagesResult.rows)
     }
 }

--- a/src/page-storage/deletion.js
+++ b/src/page-storage/deletion.js
@@ -2,15 +2,17 @@ import db from 'src/pouchdb'
 import { findVisits } from 'src/search/find-visits'
 import { getEquivalentPages } from 'src/search/find-pages'
 
-export async function deleteVisitAndPage({visitId}) {
+export async function deleteVisitAndPage({visitId, deleteAssoc = false}) {
     // Delete the visit object
     const visit = await db.get(visitId)
     const pageId = visit.page._id
     await db.remove(visit)
 
-    // If this was the only visit linking to the page, also remove the page.
-    // (a simple choice for now; this behaviour may be changed in the future)
-    await deletePageIfOrphaned({pageId})
+    if (deleteAssoc) {
+        // If this was the only visit linking to the page, also remove the page.
+        // (a simple choice for now; this behaviour may be changed in the future)
+        await deletePageIfOrphaned({pageId})
+    }
 }
 
 async function deletePageIfOrphaned({pageId}) {


### PR DESCRIPTION
Issue #16 

Mostly set up and working. Three choices when the user clicks the trashcan:
- delete just the visit
- delete the visit and associated docs (page, other visits to URL)
- cancel

Currently the associated docs choice just deletes the page if it's an orphan (no other visits pointing to it). 

TODO: 

- [x] delete other visits + the page (and any referred pages)

Could improve the styles a bit.

[How it looks/works now](https://media.giphy.com/media/xUA7aLCBr26PE7cL60/giphy.gif)