### PR TITLE
Move URL checks away from `tldjs` - fixes #111

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "search-index": "^0.13.0",
     "stopword": "^0.1.6",
     "stream-browserify": "^2.0.1",
-    "tldjs": "^1.7.0",
     "url-regex": "^4.1.1",
     "webextension-polyfill": "^0.1.1",
     "when-all-settled": "^0.1.1"

--- a/src/omnibar.js
+++ b/src/omnibar.js
@@ -7,6 +7,7 @@ import moment from 'moment'
 import shortUrl from 'src/util/short-url'
 import indexSearch from 'src/search'
 import extractTimeFiltersFromQuery from 'src/util/nlp-time-filter'
+import { OVERVIEW_URL } from 'src/background'
 
 
 // Read which browser we are running in.
@@ -99,7 +100,7 @@ const formOverviewQuery = text => {
     const queryFilters = extractTimeFiltersFromQuery(text)
     const queryParams = qs.stringify(queryFilters)
 
-    return `/overview/overview.html?${queryParams}`
+    return `${OVERVIEW_URL}?${queryParams}`
 }
 
 const acceptInput = (text, disposition) => {

--- a/src/omnibar.js
+++ b/src/omnibar.js
@@ -1,6 +1,6 @@
 import debounce from 'lodash/fp/debounce'
 import escapeHtml from 'lodash/fp/escape'
-import tldjs from 'tldjs'
+import urlRegex from 'url-regex'
 import queryString from 'query-string'
 import moment from 'moment'
 
@@ -109,7 +109,7 @@ const formOverviewQuery = text => {
 
 const acceptInput = (text, disposition) => {
     // Either go to URL if input is valid URL, else form query for overview search using input terms
-    const url = tldjs.isValid(text) ? text : formOverviewQuery(text)
+    const url = urlRegex().test(text) ? text : formOverviewQuery(text)
 
     switch (disposition) {
         case 'currentTab':

--- a/src/omnibar.js
+++ b/src/omnibar.js
@@ -96,29 +96,30 @@ async function makeSuggestion(query, suggest) {
     latestResolvedQuery = query
 }
 
-const acceptInput = (text, disposition) => {
-    // Checks whether the text is a suggested url
-    const validUrl = tldjs.isValid(text)
-    const {
-        startDate,
-        endDate,
-        extractedQuery,
-    } = extractTimeFiltersFromQuery(text)
-
+/**
+ * @param {string} text The omnibar text input.
+ * @returns {string} Overview page URL with `text` formatted as query string params.
+ */
+const formOverviewQuery = text => {
+    const { startDate, endDate, extractedQuery } = extractTimeFiltersFromQuery(text)
     const params = queryString.stringify({ query: extractedQuery, startDate, endDate })
-    const overviewPageWithQuery = `/overview/overview.html?${params}`
 
-    const goToUrl = validUrl ? text : overviewPageWithQuery
+    return `/overview/overview.html?${params}`
+}
+
+const acceptInput = (text, disposition) => {
+    // Either go to URL if input is valid URL, else form query for overview search using input terms
+    const url = tldjs.isValid(text) ? text : formOverviewQuery(text)
 
     switch (disposition) {
         case 'currentTab':
-            browser.tabs.update({url: goToUrl})
+            browser.tabs.update({ url })
             break
         case 'newForegroundTab':
-            browser.tabs.create({url: goToUrl})
+            browser.tabs.create({ url })
             break
         case 'newBackgroundTab':
-            browser.tabs.create({url: goToUrl, active: false})
+            browser.tabs.create({ url, active: false })
             break
     }
 }

--- a/src/popup/container.js
+++ b/src/popup/container.js
@@ -117,8 +117,8 @@ class PopupContainer extends Component {
         if (event.key === 'Enter') {
             event.preventDefault()
 
-            const { extractedQuery, startDate, endDate } = extractTimeFiltersFromQuery(this.state.searchValue)
-            const queryParams = qs.stringify({ query: extractedQuery, startDate, endDate })
+            const queryFilters = extractTimeFiltersFromQuery(this.state.searchValue)
+            const queryParams = qs.stringify(queryFilters)
 
             browser.tabs.create({ url: `${constants.OVERVIEW_URL}?${queryParams}` }) // New tab with query
             window.close() // Close the popup

--- a/src/util/nlp-time-filter.js
+++ b/src/util/nlp-time-filter.js
@@ -3,7 +3,20 @@ import chrono from 'chrono-node'
 const BEFORE_REGEX = /before:"(.*?)"/
 const AFTER_REGEX = /after:"(.*?)"/
 
-// Takes in query as a string and extracts startDate and endDate
+/**
+ * @typedef QueryFilters
+ * @type {Object}
+ * @property {string} query The non-date-filter search terms.
+ * @property {number|undefined} startDate Number of ms representing the start of filter time.
+ * @property {number|undefined} endDate Number of ms representing the end of filter time.
+ */
+
+/**
+ * Takes in query as a string and extracts startDate, endDate, and query parts.
+ *
+ * @param {string} query The query string that user has entered.
+ * @returns {QueryFilters} The extracted query parameters.
+ */
 export default function extractTimeFiltersFromQuery(query) {
     const matchedBefore = query.match(BEFORE_REGEX)
     const matchedAfter = query.match(AFTER_REGEX)
@@ -27,6 +40,6 @@ export default function extractTimeFiltersFromQuery(query) {
     return {
         startDate,
         endDate,
-        extractedQuery,
+        query: extractedQuery,
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8368,12 +8368,6 @@ timers-browserify@^1.0.1:
   dependencies:
     process "~0.11.0"
 
-tldjs@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/tldjs/-/tldjs-1.7.0.tgz#33de08e59d32e02f2be850096476d671b1431a81"
-  dependencies:
-    punycode "^1.4.1"
-
 tlds@^1.187.0:
   version "1.194.0"
   resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.194.0.tgz#55bfb34859229e492497580b0040e7be58d171cd"


### PR DESCRIPTION
`tldjs` package was used for checking validity of URLs when:
- opening Overview (decide to open in new or current tab)
- pressing enter in omnibar on WorldBrain search (decide if input is a URL, and nav to that URL if so, else append input as query string to Overview URL)

The package is more suited for work with domain-specific stuff however, hence was a bit weird for use here. Often resulted in false positives with `domain.tld`-like patterns (which we use in our search query "language") as seen in #111.

Replaced with `url-regex` package, which we are already using in other parts, which seems to be much more appropriate for in these two cases.

May bring `tldjs` back later; useful for domain-specific stuff.