### PR TITLE
Open new tab after click on result in overview

### DIFF
--- a/src/overview/components/PageResultItem.jsx
+++ b/src/overview/components/PageResultItem.jsx
@@ -33,7 +33,7 @@ const PageResultItem = ({ doc, sizeInMB, onTrashButtonClick, compact = false, is
         )
 
     return (
-        <a className={getMainClasses({ compact })} href={doc.url}>
+        <a className={getMainClasses({ compact })} href={doc.url} target='_blank'>
             {isBookmark && <div className={styles.bookmarkRibbon} />}
             <div className={styles.screenshotContainer}>
                 {doc._attachments && doc._attachments.screenshot


### PR DESCRIPTION
In the current version when we click on the result in overview page it open open in current tab, when user wants to go again on overview page the result again fetch.
This pull request contains open in new-tab when we click on the result.