### PR TITLE
MVP demo of moving from search-index to a simple keyword lookup

### DIFF
--- a/src/activity-logger/background/log-page-visit.js
+++ b/src/activity-logger/background/log-page-visit.js
@@ -39,10 +39,11 @@ async function updateIndex(finalPagePromise, visit) {
         if (existingIndexedDoc) {
             await index.addVisit(visit)
         } else {
-            await index.addPageConcurrent({ pageDoc: page, visitDocs: [visit] })
+            await index.addPage({ pageDoc: page, visitDocs: [visit] })
         }
     } catch (error) {
         // Indexing issue; log it for now
+        throw error
         console.error(error)
     }
 }

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -40,6 +40,7 @@ export default async function indexSearch({
     }
 
     // Get index results, filtering out any unexpectedly structured results
+    console.log(indexQuery)
     let results = await index.search(indexQuery)
     results = filterBadlyStructuredResults(results)
 
@@ -53,8 +54,12 @@ export default async function indexSearch({
         }
     }
 
+    console.log('YAY non-zero number of results')
+
     // Match the index results to data docs available in Pouch, consolidating meta docs
     const docs = await mapResultsToPouchDocs(results, { startDate, endDate })
+
+    console.log('DOCS from results', docs)
 
     return {
         docs,

--- a/src/search/map-search-to-pouch.js
+++ b/src/search/map-search-to-pouch.js
@@ -78,6 +78,8 @@ export default async function mapResultsToPouchDocs(results, timeFilters) {
     // Convert results to dictionary of page IDs to related meta IDs
     const resultIdsDict = createResultIdsDict(timeFilters)(results)
 
+    console.log('ResultIDsDict', resultIdsDict)
+
     // Format IDs of docs needed to be immediately fetched from Pouch
     const bulkGetInput = results.map(result => ({ id: result.document.id }))
 


### PR DESCRIPTION
Hi WorldBrain team!

Over the weekend Oli and I talked through the way searching happens, and concluded that it might be possible to bypass using a fully-featured search library like `search-index` by constructing a simple keyword index.

This PR is a proof-of-concept that this is possible with perhaps a few hundred lines of code.

It's very rough around the edges - I hooked into all the existing calls that are structured for `search-index`, instead using IndexedDB via level as a simple key-value store.

It should 'just work', but there are some things I didn't have time to implement/fix, e.g.:

- paging results
- I just disabled the count method for now, but this means the loading animation keeps going
- there is no stopword filtering

I hope this proves useful, but it's mostly an experiment. It will be important to fix (at least) the above things before testing the performance of this.

Please tag me if you have any questions, and if I have time I'd be happy to collaborate on debugging or optimising this approach.