### PR TITLE
Fixed the bug causing imports to fail on pdf's

### DIFF
--- a/src/page-analysis/background/fetch-page-data.js
+++ b/src/page-analysis/background/fetch-page-data.js
@@ -1,5 +1,6 @@
 import extractPageContent from 'src/page-analysis/content_script/extract-page-content'
 import extractFavIcon from 'src/page-analysis/content_script/extract-fav-icon'
+import extractPdfContent from 'src/page-analysis/content_script/extract-pdf-content'
 
 /**
  * @typedef IFetchPageDataOpts
@@ -26,7 +27,17 @@ export const defaultOpts = {
 export default async function fetchPageData(
     { url = '', timeout = 10000, opts = defaultOpts } = { opts: defaultOpts },
 ) {
+    // Check if pdf and run code for pdf instead
+    if (url.endsWith('.pdf')) {
+        return {
+            content: opts.includePageContent
+                ? await extractPdfContent({ url })
+                : undefined,
+        }
+    }
+
     const doc = await fetchDOMFromUrl(url, timeout)
+
     // If DOM couldn't be fetched, then we can't get anything
     if (!doc) {
         throw new Error('Cannot fetch DOM')

--- a/src/page-analysis/content_script/extract-pdf-content.js
+++ b/src/page-analysis/content_script/extract-pdf-content.js
@@ -1,3 +1,5 @@
+import transformPageText from 'src/util/transform-page-text'
+
 // Run PDF.js to extract text from each page and read document metadata.
 async function extractContent(pdfData) {
     // Import PDF.js only when needed, as it is large.
@@ -19,13 +21,15 @@ async function extractContent(pdfData) {
         pageTexts.push(pageText)
     }
 
-    // Join the texts of the pages with a small line, for human readability.
-    const fullText = pageTexts.join('\n\n----------\n\n')
+    // Run the joined texts through our pipeline
+    const { text: processedText } = transformPageText({
+        text: pageTexts.join(' '),
+    })
 
     const metadata = await pdf.getMetadata()
 
     return {
-        fullText,
+        fullText: processedText,
         author: metadata.info.Author,
         title: metadata.info.Title,
         keywords: metadata.info.Keywords,


### PR DESCRIPTION
- Also added the pdf extractor to the transform-text pipeline

@oliversauter The fact that the pdf-extractor for websites we visit wasn't being run through the pipeline may have been a reason for some of the terms not being removed when expected.