### PR TITLE
Import estimates/items list derivation improvements

### DIFF
--- a/src/activity-logger/index.js
+++ b/src/activity-logger/index.js
@@ -14,6 +14,14 @@ export const PAUSE_STORAGE_KEY = 'is-logging-paused'
 export function isLoggable({ url }) {
     // Just remember http(s) pages, ignoring data uris, newtab, ...
     const loggableUrlPattern = /^https?:\/\//
+    const urlEndings = ['.svg', '.jpg', '.png', '.jpeg', '.gif']
+
+    // Ignore all pages that are image files
+    for (let i = 0; i < urlEndings.length; i++) {
+        if (url.endsWith(urlEndings[i])) {
+            return false
+        }
+    }
     return loggableUrlPattern.test(url)
 }
 

--- a/src/imports/background/import-estimates.js
+++ b/src/imports/background/import-estimates.js
@@ -11,7 +11,8 @@ import {
 
 /**
  * Handles calculating the estimate counts for history and bookmark imports.
- * @returns {any} The state containing import estimates completed and remaining counts.
+ *
+ * @returns {Promise<any>} The state containing import estimates completed and remaining counts for each import type.
  */
 export default async function getEstimateCounts() {
     // Grab needed data from browser API (filtered by whats already in DB)
@@ -24,7 +25,7 @@ export default async function getEstimateCounts() {
     bookmarkItemsMap = differMaps(oldExtItems.importItemsMap)(bookmarkItemsMap)
     historyItemsMap = differMaps(bookmarkItemsMap)(historyItemsMap)
 
-    // Grab needed data from DB
+    // Grab existing data counts from DB
     const { rows: pageDocs } = await db.allDocs({
         startkey: pageKeyPrefix,
         endkey: `${pageKeyPrefix}\uffff`,

--- a/src/imports/background/import-item-processor.js
+++ b/src/imports/background/import-item-processor.js
@@ -122,11 +122,11 @@ async function processOldExtImport(importItem) {
 /**
  * Given an import state item, performs appropriate processing depending on the import type.
  *
- * @param {IImportItem} importItem The import state item to process.
- * @returns {any} Status string denoting the outcome of import processing as `status`
+ * @param {[string, IImportItem]} Key-value pair of encoded URL to import item value.
+ * @returns {string} Status string denoting the outcome of import processing as `status`
  *  + optional filled-out page doc as `pageDoc` field.
  */
-export default async function processImportItem([url, importItem = {}]) {
+export default async function processImportItem([encodedUrl, importItem = {}]) {
     switch (importItem.type) {
         case IMPORT_TYPE.BOOKMARK:
         case IMPORT_TYPE.HISTORY:

--- a/src/imports/background/import-item-processor.js
+++ b/src/imports/background/import-item-processor.js
@@ -126,7 +126,7 @@ async function processOldExtImport(importItem) {
  * @returns {any} Status string denoting the outcome of import processing as `status`
  *  + optional filled-out page doc as `pageDoc` field.
  */
-export default async function processImportItem(importItem = {}) {
+export default async function processImportItem([url, importItem = {}]) {
     switch (importItem.type) {
         case IMPORT_TYPE.BOOKMARK:
         case IMPORT_TYPE.HISTORY:

--- a/src/imports/background/imports-connection-handler.js
+++ b/src/imports/background/imports-connection-handler.js
@@ -23,8 +23,8 @@ import {
 } from '../'
 
 /**
- * Handles building the list of import items in local storage. Note that these are only
- * built in local storage as a way to persist them.
+ * Handles building the collection of import items in local storage.
+ *
  * @param {any} allowTypes Object containings bools for each valid type of import, denoting whether
  *   or not import and page docs should be created for that import type.
  */

--- a/src/imports/background/imports-connection-handler.js
+++ b/src/imports/background/imports-connection-handler.js
@@ -1,4 +1,5 @@
 import PromiseBatcher from 'src/util/promise-batcher'
+import { decode } from 'src/util/encode-url-for-id'
 import {
     CMDS,
     IMPORT_CONN_NAME,
@@ -54,14 +55,20 @@ async function prepareImportItems(allowTypes = {}) {
  */
 const getBatchObserver = port => {
     const handleFinishedItem = ({
-        input: [url, { type }],
+        input: [encodedUrl, { type }],
         output: { status } = {},
         error,
     }) => {
         // Send item data + outcome status down to UI (and error if present)
-        port.postMessage({ cmd: CMDS.NEXT, url, type, status, error })
+        port.postMessage({
+            cmd: CMDS.NEXT,
+            url: decode(encodedUrl),
+            type,
+            status,
+            error,
+        })
 
-        removeImportItem(url)
+        removeImportItem(encodedUrl)
     }
 
     return {

--- a/src/imports/background/imports-connection-handler.js
+++ b/src/imports/background/imports-connection-handler.js
@@ -36,7 +36,7 @@ async function prepareImportItems(allowTypes = {}) {
         ? await getURLFilteredBookmarkItems()
         : new Map()
     const oldExtItemsMap = allowTypes[IMPORT_TYPE.OLD]
-        ? (await getOldExtItems()).importItems
+        ? (await getOldExtItems()).importItemsMap
         : new Map()
 
     // Union all import item maps, allowing old ext items precedence over bookmarks which have

--- a/src/imports/background/imports-connection-handler.js
+++ b/src/imports/background/imports-connection-handler.js
@@ -141,7 +141,7 @@ export default async function importsConnectionHandler(port) {
     const batch = new PromiseBatcher({
         inputBatchCallback: getImportItems,
         processingCallback: processImportItem,
-        concurrency: 1,
+        concurrency: 3,
         observer: getBatchObserver(port),
     })
 

--- a/src/imports/background/index.js
+++ b/src/imports/background/index.js
@@ -160,10 +160,12 @@ export async function getOldExtItems() {
     // For everything in local storage, if the key represents page data, transform it
     for (const key in entireStorage) {
         if (Number.isInteger(+key)) {
-            importItemsMap.set(
-                encodeUrl(entireStorage[key].url),
-                transform(entireStorage[key]),
-            )
+            try {
+                const encodedUrl = encodeUrl(entireStorage[key].url)
+                importItemsMap.set(encodedUrl, transform(entireStorage[key]))
+            } catch (error) {
+                continue // Malformed URL
+            }
         }
     }
 

--- a/src/options/imports/reducers.js
+++ b/src/options/imports/reducers.js
@@ -86,8 +86,7 @@ const finishImportsReducer = ({ loading = false }) => state => ({
 const prepareImportReducer = state => ({
     ...state,
     importStatus: STATUS.LOADING,
-    loadingMsg:
-        'Preparing import. Can take a few minutes for large histories...',
+    loadingMsg: 'Preparing import.',
 })
 
 const cancelImportReducer = state => ({

--- a/src/util/map-set-helpers.js
+++ b/src/util/map-set-helpers.js
@@ -1,3 +1,5 @@
+// TODO: either make these more consistent or find some util lib that does the same
+
 /**
  * @param {Map<any,any>[]} mapArr
  * @returns {Map<any,any>} Intersection Map of all input maps
@@ -45,5 +47,8 @@ export const containsEmptyVals = iterable =>
 export const unionNestedMaps = map =>
     new Map([...map.values()].reduce((acc, value) => [...acc, ...value], []))
 
+/**
+ * Performs set difference on the provided Maps.
+ */
 export const differMaps = b => a =>
     new Map([...a].filter(([key]) => !b.has(key)))

--- a/src/util/map-set-helpers.js
+++ b/src/util/map-set-helpers.js
@@ -44,3 +44,6 @@ export const containsEmptyVals = iterable =>
  */
 export const unionNestedMaps = map =>
     new Map([...map.values()].reduce((acc, value) => [...acc, ...value], []))
+
+export const differMaps = b => a =>
+    new Map([...a].filter(([key]) => !b.has(key)))


### PR DESCRIPTION
Import item list (also used for deriving estimate counts) now stored as `Map` of normalized + encoded URLs -> import items. Previously was `Array` of import items.

- custom Pouch.find queries moved to standard Pouch.allDocs queries
- normalization on import item keys means a lot of semantically-identical (in our context) URLs will now be properly filtered out
- bookmarks and history counts should make more sense for users (proper distinction made). Old ext imports is still a bit of an odd-case as each old-ext import will increase either the history or bookmark AND old-ext "already saved" count
- put concurrency setting back into imports processor (currently set at 3 items at any time). Concurrency queue implemented a bit back should guarantee safety at DB-level for indexing, allowing us to do stuff like the XHRs concurrently (still won't move onto the next import item until all DB ops are finished). Need to see if any weird behaviour, but initial play with this seems fine