### PR TITLE
Change latest event timestamp behaviour in search

### DIFF
--- a/src/bookmarks/background/deletion.js
+++ b/src/bookmarks/background/deletion.js
@@ -28,7 +28,6 @@ async function removeBookmarkByUrl(url) {
     await index.put(pageId, {
         ...reverseIndexDoc,
         bookmarks: new Set(),
-        type: 'visit',
     })
 
     // Remove corresponding bookmark docs from pouch

--- a/src/omnibar.js
+++ b/src/omnibar.js
@@ -41,7 +41,7 @@ function setOmniboxMessage(text) {
 const pageToSuggestion = timeFilterApplied => doc => {
     const url = escapeHtml(shortUrl(doc.url))
     const title = escapeHtml(doc.content.title)
-    const time = formatTime(doc[doc.displayType], timeFilterApplied)
+    const time = formatTime(+doc.displayTime, timeFilterApplied)
 
     return {
         content: doc.url,

--- a/src/overview/components/PageResultItem.jsx
+++ b/src/overview/components/PageResultItem.jsx
@@ -1,108 +1,62 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
 import classNames from 'classnames'
 
 import niceTime from 'src/util/nice-time'
-
 import ImgFromPouch from './ImgFromPouch'
 import styles from './PageResultItem.css'
-import { showDeleteConfirm } from '../actions'
-import * as constants from '../constants'
 
-// Format either visit, bookmark, or nothing, depending on doc `displayType`.
-const renderTime = ({ doc }) =>
-    doc.displayType !== constants.RESULT_TYPES.UNKNOWN
-        ? niceTime(doc[doc.displayType])
-        : ''
-
-const getMainClasses = ({ compact }) =>
-    classNames({
-        [styles.root]: true,
-        [styles.compact]: compact,
+const getBookmarkClass = ({ hasBookmark }) =>
+    classNames(styles.button, {
+        [styles.bookmark]: hasBookmark,
+        [styles.notBookmark]: !hasBookmark,
     })
 
-const getBookmarkClass = ({ doc, showOnlyBookmarks }) => {
-    const isBookmark =
-        showOnlyBookmarks || doc.displayType === constants.RESULT_TYPES.BOOKMARK
-
-    return classNames({
-        [styles.button]: true,
-        [styles.bookmark]: isBookmark,
-        [styles.notBookmark]: !isBookmark,
-    })
-}
-
-const PageResultItem = ({
-    doc,
-    onTrashButtonClick,
-    compact = false,
-    showOnlyBookmarks,
-}) => {
-    const hasFavIcon = !!(doc._attachments && doc._attachments.favIcon)
-    const favIcon = hasFavIcon && (
-        <ImgFromPouch
-            className={styles.favIcon}
-            doc={doc}
-            attachmentId="favIcon"
-        />
-    )
-
-    return (
-        <a
-            className={getMainClasses({ compact })}
-            href={doc.url}
-            target="_blank"
-        >
-            <div className={styles.screenshotContainer}>
-                {doc._attachments && doc._attachments.screenshot ? (
-                    <ImgFromPouch
-                        className={styles.screenshot}
-                        doc={doc}
-                        attachmentId="screenshot"
-                    />
-                ) : (
-                    <img
-                        className={styles.screenshot}
-                        src="/img/null-icon.png"
-                    />
-                )}
-            </div>
-            <div className={styles.descriptionContainer}>
-                <div className={styles.title} title={doc.title}>
-                    {hasFavIcon && favIcon}
-                    {doc.title}
-                </div>
-                <div className={styles.url}>{doc.url}</div>
-                <div className={styles.time}>{renderTime({ doc })}</div>
-            </div>
-            <div className={styles.buttonsContainer}>
-                <button
-                    className={getBookmarkClass({ doc, showOnlyBookmarks })}
+const PageResultItem = props => (
+    <a className={styles.root} href={props.url} target="_blank">
+        <div className={styles.screenshotContainer}>
+            {props._attachments && props._attachments.screenshot ? (
+                <ImgFromPouch
+                    className={styles.screenshot}
+                    doc={props}
+                    attachmentId="screenshot"
                 />
-                <button
-                    className={`${styles.button} ${styles.trash}`}
-                    onClick={onTrashButtonClick}
-                />
+            ) : (
+                <img className={styles.screenshot} src="/img/null-icon.png" />
+            )}
+        </div>
+        <div className={styles.descriptionContainer}>
+            <div className={styles.title} title={props.title}>
+                {props._attachments &&
+                    props._attachments.favIcon && (
+                        <ImgFromPouch
+                            className={styles.favIcon}
+                            doc={props}
+                            attachmentId="favIcon"
+                        />
+                    )}
+                {props.title}
             </div>
-        </a>
-    )
-}
+            <div className={styles.url}>{props.url}</div>
+            <div className={styles.time}>{niceTime(+props.displayTime)}</div>
+        </div>
+        <div className={styles.buttonsContainer}>
+            <button className={getBookmarkClass(props)} />
+            <button
+                className={classNames(styles.button, styles.trash)}
+                onClick={props.onTrashBtnClick}
+            />
+        </div>
+    </a>
+)
 
 PageResultItem.propTypes = {
-    doc: PropTypes.object.isRequired,
-    compact: PropTypes.bool,
-    showOnlyBookmarks: PropTypes.bool,
-    onTrashButtonClick: PropTypes.func,
+    _attachments: PropTypes.object.isRequired,
+    displayTime: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    hasBookmark: PropTypes.bool.isRequired, // eslint-disable-line
+    onTrashBtnClick: PropTypes.func.isRequired,
 }
 
-const mapStateToProps = state => ({})
-
-const mapDispatchToProps = (dispatch, { doc }) => ({
-    onTrashButtonClick: e => {
-        e.preventDefault()
-        dispatch(showDeleteConfirm(doc.url))
-    },
-})
-
-export default connect(mapStateToProps, mapDispatchToProps)(PageResultItem)
+export default PageResultItem

--- a/src/overview/components/PageResultItem.jsx
+++ b/src/overview/components/PageResultItem.jsx
@@ -35,7 +35,6 @@ const getBookmarkClass = ({ doc, showOnlyBookmarks }) => {
 
 const PageResultItem = ({
     doc,
-    sizeInMB,
     onTrashButtonClick,
     compact = false,
     showOnlyBookmarks,
@@ -84,7 +83,6 @@ const PageResultItem = ({
                 <button
                     className={`${styles.button} ${styles.trash}`}
                     onClick={onTrashButtonClick}
-                    title={`Forget this item (${sizeInMB} MB)`}
                 />
             </div>
         </a>
@@ -93,7 +91,6 @@ const PageResultItem = ({
 
 PageResultItem.propTypes = {
     doc: PropTypes.object.isRequired,
-    sizeInMB: PropTypes.string.isRequired,
     compact: PropTypes.bool,
     showOnlyBookmarks: PropTypes.bool,
     onTrashButtonClick: PropTypes.func,

--- a/src/overview/container.js
+++ b/src/overview/container.js
@@ -55,7 +55,6 @@ class OverviewContainer extends Component {
             <li key={doc._id}>
                 <PageResultItem
                     doc={doc}
-                    sizeInMB={doc.freezeDrySize}
                     showOnlyBookmarks={showOnlyBookmarks}
                 />
             </li>

--- a/src/overview/container.js
+++ b/src/overview/container.js
@@ -21,9 +21,9 @@ class OverviewContainer extends Component {
         isNewSearchLoading: PropTypes.bool.isRequired,
         noResults: PropTypes.bool.isRequired,
         isBadTerm: PropTypes.bool.isRequired,
-        showOnlyBookmarks: PropTypes.bool.isRequired,
         searchResults: PropTypes.arrayOf(PropTypes.object).isRequired,
         needsWaypoint: PropTypes.bool.isRequired,
+        handleTrashBtnClick: PropTypes.func.isRequired,
     }
 
     componentDidMount() {
@@ -43,32 +43,27 @@ class OverviewContainer extends Component {
     }
 
     renderResultItems() {
-        const {
-            searchResults,
-            onBottomReached,
-            isLoading,
-            needsWaypoint,
-            showOnlyBookmarks,
-        } = this.props
-
-        const resultItems = searchResults.map(doc => (
+        const resultItems = this.props.searchResults.map(doc => (
             <li key={doc._id}>
                 <PageResultItem
-                    doc={doc}
-                    showOnlyBookmarks={showOnlyBookmarks}
+                    onTrashBtnClick={this.props.handleTrashBtnClick(doc.url)}
+                    {...doc}
                 />
             </li>
         ))
 
         // Insert waypoint at the end of results to trigger loading new items when scrolling down
-        if (needsWaypoint) {
+        if (this.props.needsWaypoint) {
             resultItems.push(
-                <Waypoint onEnter={onBottomReached} key="waypoint" />,
+                <Waypoint
+                    onEnter={this.props.onBottomReached}
+                    key="waypoint"
+                />,
             )
         }
 
-        // Add loading spinner to the list end, if loading (may change this)
-        if (isLoading) {
+        // Add loading spinner to the list end, if loading
+        if (this.props.isLoading) {
             resultItems.push(<LoadingIndicator key="loading" />)
         }
 
@@ -131,8 +126,8 @@ const mapStateToProps = state => ({
     showOnlyBookmarks: selectors.showOnlyBookmarks(state),
 })
 
-const mapDispatchToProps = dispatch =>
-    bindActionCreators(
+const mapDispatchToProps = dispatch => ({
+    ...bindActionCreators(
         {
             onInputChange: actions.setQuery,
             onStartDateChange: actions.setStartDate,
@@ -144,6 +139,11 @@ const mapDispatchToProps = dispatch =>
             onShowOnlyBookmarksChange: actions.toggleBookmarkFilter,
         },
         dispatch,
-    )
+    ),
+    handleTrashBtnClick: url => event => {
+        event.preventDefault()
+        dispatch(actions.showDeleteConfirm(url))
+    },
+})
 
 export default connect(mapStateToProps, mapDispatchToProps)(OverviewContainer)

--- a/src/overview/selectors.js
+++ b/src/overview/selectors.js
@@ -1,22 +1,6 @@
 import { createSelector } from 'reselect'
-import get from 'lodash/fp/get'
 
 import * as constants from './constants'
-
-/**
- * Given an augmented page doc, attempts to calculate its approx. freeze dry page size in MB.
- * @param {any} pageDoc The augmented page doc from search results.
- * @returns {string} Approx. size in MB of freeze-dry attachment. 0 if not found.
- */
-function calcFreezeDrySize(pageDoc) {
-    const pageSize = get(['_attachments', 'frozen-page.html', 'length'])(
-        pageDoc,
-    )
-    const sizeInMB =
-        pageSize !== undefined ? Math.round(pageSize / 1024 ** 2 * 10) / 10 : 0
-
-    return sizeInMB.toString()
-}
 
 /**
  * Either set display title to be the top-level title field, else look in content. Fallback is the URL.
@@ -71,7 +55,6 @@ export const urlToDelete = createSelector(
 export const results = createSelector(resultDocs, docs =>
     docs.map(pageDoc => ({
         ...pageDoc,
-        freezeDrySize: calcFreezeDrySize(pageDoc),
         title: decideTitle(pageDoc),
     })),
 )

--- a/src/overview/selectors.js
+++ b/src/overview/selectors.js
@@ -23,11 +23,6 @@ export const currentQueryParams = createSelector(
     state => state.currentQueryParams,
 )
 
-export const isEmptyQuery = createSelector(
-    currentQueryParams,
-    ({ query, startDate, endDate }) => !query.length && !startDate && !endDate,
-)
-
 export const isLoading = createSelector(overview, state => state.isLoading)
 export const noResults = createSelector(
     resultDocs,
@@ -81,3 +76,10 @@ export const isNewSearchLoading = createSelector(
 )
 export const showFilter = state => overview(state).showFilter
 export const showOnlyBookmarks = state => overview(state).showOnlyBookmarks
+
+export const isEmptyQuery = createSelector(
+    currentQueryParams,
+    showOnlyBookmarks,
+    ({ query, startDate, endDate }, showOnlyBookmarks) =>
+        !query.length && !startDate && !endDate && !showOnlyBookmarks,
+)

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -52,7 +52,11 @@ async function indexSearch({
     }
 
     // Match the index results to data docs available in Pouch, consolidating meta docs
-    const docs = await mapResultsToPouchDocs(results, { startDate, endDate })
+    const docs = await mapResultsToPouchDocs(results, {
+        startDate,
+        endDate,
+        showOnlyBookmarks,
+    })
 
     console.log('DEBUG: final UI results', docs)
 

--- a/src/search/map-search-to-pouch.js
+++ b/src/search/map-search-to-pouch.js
@@ -4,12 +4,11 @@ import db, { bulkGetResultsToArray } from 'src/pouchdb'
 import { removeKeyType } from './search-index/util'
 
 /**
- * Iterates through at most log N of the input timestamps (where N is timestamps.length).
  * @param {Array<string>} timestamps
  * @param {string} endDate
  * @returns {number} Index of the element most closely being less than or equal to the `endDate`.
  */
-const simpleTimestampBinSearch = (timestamps = [], endDate) => {
+const timestampsBinSearch = (timestamps = [], endDate = Date.now()) => {
     let min = 0
     let max = timestamps.length - 1
     let curr = -1
@@ -30,45 +29,46 @@ const simpleTimestampBinSearch = (timestamps = [], endDate) => {
 }
 
 /**
-* NOTE: Assumes order for O(1) "lookup" of latest time, but O(log N) in case of endDate set
-* @param {Set<string>} timestamps Set of timestamp strings to get latest (last) one.
-* @returns {string} The latest timestamp
-*/
-const getLatestTime = (timestamps, { startDate, endDate }) => {
-    timestamps = [...timestamps].map(removeKeyType).sort()
+ * @param {any} timeFilter
+ * @returns {(timestampsSet: Set<string>) => string} Function that returns latest timestamp in bookmarks/visits Set.
+ */
+const initFindLatestTime = ({ endDate }) => timestampsSet => {
+    const timestamps = [...timestampsSet].map(removeKeyType).sort()
 
-    // If endDate defined, need to return latest before endDate
-    if (endDate) {
-        return timestamps[simpleTimestampBinSearch(timestamps, endDate)]
-    }
+    return timestamps[timestampsBinSearch(timestamps, endDate)]
+}
 
-    // If not, the latest will be at the end
-    return timestamps[timestamps.length - 1]
+/**
+ * @param {IndexLookupDoc} resultDoc Contains `visits` and `bookmarks` Sets.
+ * @param {any} timeFilter
+ * @returns {string} Latest visit or bookmark timestamp, depending on available data.
+ */
+function getLatestTime({ visits, bookmarks }, timeFilter) {
+    const findLatest = initFindLatestTime(timeFilter)
+
+    // Only use bookmark times if no visits
+    return !visits.size ? findLatest(bookmarks) : findLatest(visits)
 }
 
 /**
 * Creates a quick-lookup dictionary of page doc IDs to the associated meta doc IDs
 * from our search-index results. The index result score is also kept for later sorting.
-* @param {Array<any>} results Array of search-idnex results.
-* @returns {any} Object with page ID keys and values containing either bookmark or visit or both docs.
+* @param {Array<any>} results Array of search index results.
+* @returns {Map<string, any>} Map with page ID keys and values containing needed search result data.
 */
-const createResultIdsDict = timeFilters =>
+const createResultsMap = timeFilters =>
     reduce(
-        (acc, result) => ({
-            ...acc,
-            [result.document.id]: {
-                pageId: result.document.id,
-                visit: getLatestTime(result.document.visits, timeFilters),
-                bookmark: getLatestTime(result.document.bookmarks, timeFilters),
+        (acc, result) =>
+            acc.set(result.id, {
+                timestamp: getLatestTime(result.document, timeFilters),
                 score: result.score,
-                displayType: result.document.type,
-            },
-        }),
-        {},
+                hasBookmark: result.document.bookmarks.size > 0,
+            }),
+        new Map(),
     )
 
-const sortByScore = resultIdsDict => (docA, docB) =>
-    resultIdsDict[docB._id].score - resultIdsDict[docA._id].score
+const sortByScore = resultsMap => (docA, docB) =>
+    resultsMap.get(docB._id).score - resultsMap.get(docA._id).score
 
 /**
 * Performs all the messy logic needed to resolve search-index results against our PouchDB model.
@@ -81,7 +81,7 @@ const sortByScore = resultIdsDict => (docA, docB) =>
 */
 export default async function mapResultsToPouchDocs(results, timeFilters) {
     // Convert results to dictionary of page IDs to related meta IDs
-    const resultIdsDict = createResultIdsDict(timeFilters)(results)
+    const resultsMap = createResultsMap(timeFilters)(results)
 
     // Format IDs of docs needed to be immediately fetched from Pouch
     const bulkGetInput = results.map(result => ({ id: result.document.id }))
@@ -90,14 +90,13 @@ export default async function mapResultsToPouchDocs(results, timeFilters) {
     const bulkRes = await db.bulkGet({ docs: bulkGetInput })
     const pageDocs = bulkGetResultsToArray(bulkRes)
 
-    // Augment the page docs with latest meta timestamp/s and type denoting the latest time for display
+    // Augment the page docs with meta display info derived from search results
     const augmentedPageDocs = pageDocs.map(doc => ({
         ...doc,
-        visit: +resultIdsDict[doc._id].visit,
-        bookmark: +resultIdsDict[doc._id].bookmark,
-        displayType: resultIdsDict[doc._id].displayType,
+        hasBookmark: resultsMap.get(doc._id).hasBookmark,
+        displayTime: resultsMap.get(doc._id).timestamp,
     }))
 
     // Ensure the original results order is maintained
-    return augmentedPageDocs.sort(sortByScore(resultIdsDict))
+    return augmentedPageDocs.sort(sortByScore(resultsMap))
 }

--- a/src/search/search-index/pipeline.js
+++ b/src/search/search-index/pipeline.js
@@ -2,7 +2,7 @@ import normalizeUrl from 'normalize-url'
 
 import transformPageText from 'src/util/transform-page-text'
 import { convertMetaDocId } from 'src/activity-logger'
-import { getLatestMeta, extractContent, keyGen } from './util'
+import { extractContent, keyGen } from './util'
 import { DEFAULT_TERM_SEPARATOR } from '.'
 
 // Simply extracts the timestamp component out the ID of a visit or bookmark doc,
@@ -45,7 +45,6 @@ function transformUrl(url) {
  * @typedef IndexLookupDoc
  * @type {Object}
  * @property {string} latest Latest visit/bookmark timestamp time for easy scoring.
- * @property {string} type Enum of either 'bookmark' or 'visit'.
  * @property {string} domain Filter term extracted from page URL.
  * @property {Set} urlTerms Set of searchable terms extracted from page URL.
  * @property {Set} terms Set of searchable terms extracted from page content.
@@ -120,7 +119,6 @@ export default function pipeline({
 
     return Promise.resolve({
         id,
-        ...getLatestMeta(visits, bookmarks),
         terms,
         urlTerms: urlTerms || new Set(),
         domain: keyGen.domain(hostname),


### PR DESCRIPTION
Search has been changed as described in the last bit of [this comment in #150](https://github.com/WorldBrain/WebMemex/pull/150#issuecomment-341942562). 
Simply: latest visit *should* always be used for search unless no visits exist for a page (only then bookmark is used).

Make sure to remove all existing data before trying this branch.